### PR TITLE
feat: add vote table, database seeding (WIP)

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -16,7 +16,8 @@
     "prisma:migrate": "pnpm prisma migrate dev",
     "prisma:generate": "pnpm prisma generate",
     "prisma:docs": "pnpm prisma-docs-generator serve",
-    "format": "prettier . --write"
+    "format": "prettier . --write",
+    "prisma:seed": "ts-node prisma/seed.ts"
   },
   "devDependencies": {
     "@faker-js/faker": "^7.6.0",

--- a/packages/api/prisma/schema.prisma
+++ b/packages/api/prisma/schema.prisma
@@ -13,47 +13,109 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
-model Round {
-  id                 Int            @id @default(autoincrement())
-  createdAt          DateTime       @default(now()) @db.Timestamptz(3)
-  updatedAt          DateTime       @updatedAt @db.Timestamptz(3)
-  chainId            ChainId
-  roundId            String         @unique
-  votingStrategyName VotingStrategy
-  matches            Match[]
-  isSaturated        Boolean        @default(false)
-  roundSummary       RoundSummary?
-  projects           Project[]
-  votes              Vote[]
+model Program {
+  id               Int      @id @default(autoincrement())
+  createdAt        DateTime @default(now()) @db.Timestamptz(3)
+  updatedAt        DateTime @updatedAt @db.Timestamptz(3)
+  chainId          String
+  programId        String
+  programCreatedAt String
+  programUpdatedAt String
+  rounds           Round[]
 
+  @@unique([chainId, programId], name: "programIdentifier")
+  @@map("program")
+}
+
+model Round {
+  id                    Int       @id @default(autoincrement())
+  createdAt             DateTime  @default(now()) @db.Timestamptz(3)
+  updatedAt             DateTime  @updatedAt @db.Timestamptz(3)
+  chainId               String
+  program               Program   @relation(fields: [chainId, programId], references: [chainId, programId])
+  programId             String
+  roundId               String
+  roundCreatedAt        String
+  roundUpdatedAt        String
+  applicationsStartTime String
+  applicationsEndTime   String
+  roundStartTime        String
+  roundEndTime          String
+  payoutStrategy        String
+  roundToken            String
+  projects              Project[]
+  matches               Match[]
+  roundSummary          RoundSummary[]
+
+  @@unique([chainId, roundId], name: "roundIdentifier")
   @@map("round")
 }
 
-model Project {
-  id               Int              @id @default(autoincrement())
-  createdAt        DateTime         @default(now()) @db.Timestamptz(3)
-  updatedAt        DateTime         @updatedAt @db.Timestamptz(3)
-  chainId          ChainId
-  round            Round            @relation(fields: [roundId], references: [roundId])
-  roundId          String
-  projectId        String
-  projectSummaries ProjectSummary[]
-  votes            Vote[]
+model VotingStrategy {
+  id              Int      @id @default(autoincrement())
+  createdAt       DateTime @default(now()) @db.Timestamptz(3)
+  updatedAt       DateTime @updatedAt @db.Timestamptz(3)
+  roundId         String
+  chainId         String
+  strategyAddress String
+  strategyName    String
+  strategyVersion String
+  strategyId      String
+  // Round           Round?
 
-  @@unique([projectId, roundId], name: "projectIdentifier")
+  @@unique([chainId, roundId], name: "votingStrategyIdentifier")
+  @@map("votingStrategy")
+}
+
+model Project {
+  id                   Int      @id @default(autoincrement())
+  createdAt            DateTime @default(now()) @db.Timestamptz(3)
+  updatedAt            DateTime @updatedAt @db.Timestamptz(3)
+  chainId              String
+  round                Round    @relation(fields: [chainId, roundId], references: [chainId, roundId])
+  roundId              String
+  projectId            String
+  projectCreatedAt     String
+  projectUpdatedAt     String
+  projectStatus        String
+  projectPayoutAddress String?
+  projectSummary       ProjectSummary[]
+
+  @@unique([projectId, roundId, chainId], name: "projectIdentifier")
   @@map("project")
+}
+
+model Vote {
+  id             Int      @id @default(autoincrement())
+  createdAt      DateTime @default(now()) @db.Timestamptz(3)
+  updatedAt      DateTime @updatedAt @db.Timestamptz(3)
+  chainId        String
+  roundId        String
+  projectId      String
+  voteId         String
+  voteAmount     String
+  voteCreatedAt  String
+  voterAddress   String
+  voteToAddress  String
+  voteToken      String
+  voteVersion    String
+  voteStrategyId String
+
+  @@unique([roundId, projectId, voteId], name: "voteIdentifier")
+  @@map("vote")
 }
 
 model Match {
   id                      Int      @id @default(autoincrement())
   createdAt               DateTime @default(now()) @db.Timestamptz(3)
   updatedAt               DateTime @updatedAt @db.Timestamptz(3)
+  chainId                 String
   projectId               String
   matchAmountInUSD        Float
   totalContributionsInUSD Float
   matchPoolPercentage     Float
   matchAmountInToken      Float
-  round                   Round    @relation(fields: [roundId], references: [roundId])
+  round                   Round    @relation(fields: [chainId, roundId], references: [chainId, roundId])
   roundId                 String
   projectPayoutAddress    String
   uniqueContributorsCount Int?
@@ -66,11 +128,12 @@ model RoundSummary {
   id                      Int      @id @default(autoincrement())
   createdAt               DateTime @default(now()) @db.Timestamptz(3)
   updatedAt               DateTime @updatedAt @db.Timestamptz(3)
+  chainId                 String
   contributionCount       Int
   uniqueContributors      Int
   totalContributionsInUSD Float
   averageUSDContribution  Float
-  round                   Round    @relation(fields: [roundId], references: [roundId])
+  round                   Round    @relation(fields: [chainId, roundId], references: [chainId, roundId])
   roundId                 String
 
   @@unique([roundId], name: "roundSummaryIdentifier")
@@ -81,51 +144,15 @@ model ProjectSummary {
   id                      Int      @id @default(autoincrement())
   createdAt               DateTime @default(now()) @db.Timestamptz(3)
   updatedAt               DateTime @updatedAt @db.Timestamptz(3)
+  chainId                 String
   contributionCount       Int
   uniqueContributors      Int
   totalContributionsInUSD Float
   averageUSDContribution  Float
-  project                 Project  @relation(fields: [projectId, roundId], references: [projectId, roundId])
+  project                 Project  @relation(fields: [projectId, roundId, chainId], references: [projectId, roundId, chainId])
   projectId               String
   roundId                 String
 
   @@unique([projectId, roundId], name: "projectSummaryIdentifier")
   @@map("projectSummary")
-}
-
-model Vote {
-  id               Int      @id @default(autoincrement())
-  createdAt        DateTime @default(now()) @db.Timestamptz(3)
-  updatedAt        DateTime @updatedAt @db.Timestamptz(3)
-  round            Round    @relation(fields: [roundId], references: [roundId])
-  roundId          String
-  project          Project  @relation(fields: [projectId, roundId], references: [projectId, roundId])
-  projectId        String
-  graphId          String
-  voteAmount       String
-  voteTimestamp    String
-  voterAddress     String
-  voteToAddress    String
-  voteToken        String
-  voteVersion      String
-
-  @@unique([roundId, projectId, graphId], name: "voteIdentifier")
-  @@map("vote")
-}
-
-// ========= //
-// = ENUMS = //
-// ========= //
-enum ChainId {
-  GOERLI
-  OPTIMISM_MAINNET
-  FANTOM_MAINNET
-  FANTOM_TESTNET
-  LOCAL_ROUND_LAB
-  MAINNET
-}
-
-enum VotingStrategy {
-  LINEAR_QUADRATIC_FUNDING
-  QUADRATIC_VOTING
 }

--- a/packages/api/prisma/schema.prisma
+++ b/packages/api/prisma/schema.prisma
@@ -24,6 +24,7 @@ model Round {
   isSaturated        Boolean        @default(false)
   roundSummary       RoundSummary?
   projects           Project[]
+  votes              Vote[]
 
   @@map("round")
 }
@@ -37,6 +38,7 @@ model Project {
   roundId          String
   projectId        String
   projectSummaries ProjectSummary[]
+  votes            Vote[]
 
   @@unique([projectId, roundId], name: "projectIdentifier")
   @@map("project")
@@ -89,6 +91,26 @@ model ProjectSummary {
 
   @@unique([projectId, roundId], name: "projectSummaryIdentifier")
   @@map("projectSummary")
+}
+
+model Vote {
+  id               Int      @id @default(autoincrement())
+  createdAt        DateTime @default(now()) @db.Timestamptz(3)
+  updatedAt        DateTime @updatedAt @db.Timestamptz(3)
+  round            Round    @relation(fields: [roundId], references: [roundId])
+  roundId          String
+  project          Project  @relation(fields: [projectId, roundId], references: [projectId, roundId])
+  projectId        String
+  graphId          String
+  voteAmount       String
+  voteTimestamp    String
+  voterAddress     String
+  voteToAddress    String
+  voteToken        String
+  voteVersion      String
+
+  @@unique([roundId, projectId, graphId], name: "voteIdentifier")
+  @@map("vote")
 }
 
 // ========= //

--- a/packages/api/prisma/seed.ts
+++ b/packages/api/prisma/seed.ts
@@ -1,31 +1,163 @@
-import { fetchGraphQFContributionsForRound, fetchGraphVotingStrategies } from "../src/utils";
-import { ChainId, GraphQFVotes, GraphResponse, GraphVotingStrategies } from "../src/types";
-import { VotingStrategy } from "@prisma/client";
+import {
+  fetchGraphMeta,
+  fetchGraphPrograms,
+  fetchGraphQFVotes,
+  fetchGraphRoundProjects,
+  fetchGraphProgramRounds,
+  fetchGraphRoundVotingStrategy,
+} from "../src/utils";
+import { ChainId, GraphResponse } from "../src/types";
 import { DatabaseInstance } from "../src/database";
 
 async function main() {
-
-  // TODO: all the other chains
-  // TODO: Check version and if < 0.2.0, use alt method to get project id
-  // TODO: Figure out whats up with the graph
-
   // Database instance
   const db = new DatabaseInstance();
 
-  // Ethereum Mainnet Voting Strategies
-  const ethMainnetVotingStrategiesResponse: GraphResponse<GraphVotingStrategies> =
-    await fetchGraphVotingStrategies(ChainId.MAINNET);
-  const ethMainnetVotingStrategies = ethMainnetVotingStrategiesResponse.data.votingStrategies;
+  let chainId: keyof typeof ChainId;
 
-  // Get the contributions for each voting strategy
-  for (const votingStrategy of ethMainnetVotingStrategies) {
-    const contributions: GraphResponse<GraphQFVotes> =
-      await fetchGraphQFContributionsForRound(ChainId.MAINNET, votingStrategy.id);
-    // TODO: db error handling
-    db.createVoteRecords(ChainId.MAINNET, votingStrategy.strategyName as VotingStrategy, contributions);
+  for (chainId in ChainId) {
+    // Get current synced graph block metadata
+    const currentBlockResponse = await fetchGraphMeta(ChainId[chainId]);
+    if (!checkResponse(currentBlockResponse)) {
+      return;
+    }
+    // look back 10 blocks
+    const blockNumber = currentBlockResponse.data._meta.block.number - 10;
+    console.log("Seeding database for", chainId, "at block", blockNumber);
+    await seedDatabaseOfChain(db, ChainId[chainId], blockNumber);
   }
-
 }
 
-// TODO: handle connection and disconnections
-main().then(() => console.log("done"));
+// Run main function
+main().then(() => {
+  // close db connection
+  process.exit(0);
+});
+
+function checkResponse(response: GraphResponse<any>) {
+  if (response.error) {
+    console.log("Error fetching data: ", response.error);
+    return false;
+  }
+
+  if (!response.data) {
+    console.log("No data found in graph");
+    return false;
+  }
+
+  return true;
+}
+
+async function seedDatabaseOfChain(
+  db: DatabaseInstance,
+  chainId: ChainId,
+  blockNumber: number
+) {
+  // Get programs
+  const programsResponse = await fetchGraphPrograms(chainId, blockNumber);
+
+  if (!checkResponse(programsResponse)) {
+    return;
+  }
+
+  // Store programs in db
+  await db.createProgramRecords(chainId, programsResponse.data.programs);
+
+  // Read programs from db
+  const programs = await db.getPrograms(chainId);
+
+  if (!programs) {
+    console.log("No programs found in db");
+    return;
+  }
+
+  // Parse program ids
+  const programIds = programs.map((program) => program.programId);
+
+  // Get rounds
+  const roundsResponse = await fetchGraphProgramRounds(
+    chainId,
+    programIds,
+    blockNumber
+  );
+
+  if (!checkResponse(roundsResponse)) {
+    return;
+  }
+
+  // Store rounds in db
+  await db.createRoundRecords(chainId, roundsResponse.data.rounds);
+
+  // Read rounds from db
+  const rounds = await db.getRounds(chainId);
+
+  if (!rounds) {
+    console.log("No rounds found in db");
+    return;
+  }
+
+  // Parse round ids
+  const roundIds = rounds.map((round) => round.roundId);
+
+  for (const roundId of roundIds) {
+    // Get projects
+    const projectsResponse = await fetchGraphRoundProjects(
+      chainId,
+      roundId,
+      blockNumber
+    );
+
+    if (!checkResponse(projectsResponse)) {
+      return;
+    }
+
+    // Store projects in db
+    await db.createProjectRecords(chainId, projectsResponse.data.roundProjects);
+  }
+
+  // Get voting strategies
+  const votingStrategiesResponse = await fetchGraphRoundVotingStrategy(
+    chainId,
+    roundIds,
+    blockNumber
+  );
+
+  if (!checkResponse(votingStrategiesResponse)) {
+    return;
+  }
+
+  // Store voting strategies in db
+  await db.createVotingStrategyRecords(
+    chainId,
+    votingStrategiesResponse.data.votingStrategies
+  );
+
+  // Read voting strategies from db
+  const votingStrategies = await db.getVotingStrategies(chainId);
+
+  if (!votingStrategies) {
+    console.log("No voting strategies found in db");
+    return;
+  }
+
+  // Parse voting strategy ids
+  const votingStrategyIds = votingStrategies.map(
+    (votingStrategy) => votingStrategy.strategyId
+  );
+
+  for (const votingStrategyId of votingStrategyIds) {
+    // Get qfvotes
+    const qfvotesResponse = await fetchGraphQFVotes(
+      chainId,
+      votingStrategyId,
+      blockNumber
+    );
+
+    if (!checkResponse(qfvotesResponse)) {
+      return;
+    }
+
+    // Store qfvotes in db
+    await db.createQFVoteRecords(chainId, qfvotesResponse.data.qfvotes);
+  }
+}

--- a/packages/api/prisma/seed.ts
+++ b/packages/api/prisma/seed.ts
@@ -1,0 +1,31 @@
+import { fetchGraphQFContributionsForRound, fetchGraphVotingStrategies } from "../src/utils";
+import { ChainId, GraphQFVotes, GraphResponse, GraphVotingStrategies } from "../src/types";
+import { VotingStrategy } from "@prisma/client";
+import { DatabaseInstance } from "../src/database";
+
+async function main() {
+
+  // TODO: all the other chains
+  // TODO: Check version and if < 0.2.0, use alt method to get project id
+  // TODO: Figure out whats up with the graph
+
+  // Database instance
+  const db = new DatabaseInstance();
+
+  // Ethereum Mainnet Voting Strategies
+  const ethMainnetVotingStrategiesResponse: GraphResponse<GraphVotingStrategies> =
+    await fetchGraphVotingStrategies(ChainId.MAINNET);
+  const ethMainnetVotingStrategies = ethMainnetVotingStrategiesResponse.data.votingStrategies;
+
+  // Get the contributions for each voting strategy
+  for (const votingStrategy of ethMainnetVotingStrategies) {
+    const contributions: GraphResponse<GraphQFVotes> =
+      await fetchGraphQFContributionsForRound(ChainId.MAINNET, votingStrategy.id);
+    // TODO: db error handling
+    db.createVoteRecords(ChainId.MAINNET, votingStrategy.strategyName as VotingStrategy, contributions);
+  }
+
+}
+
+// TODO: handle connection and disconnections
+main().then(() => console.log("done"));

--- a/packages/api/src/handlers/updateProjectSummaryHandler.ts
+++ b/packages/api/src/handlers/updateProjectSummaryHandler.ts
@@ -1,5 +1,5 @@
 import { Request, Response } from "express";
-import { VotingStrategy } from "@prisma/client";
+import { VotingStrategyName } from "@prisma/client";
 import { ChainId, QFContributionSummary, RoundMetadata } from "../types";
 import { fetchRoundMetadata, handleResponse } from "../utils";
 import {
@@ -37,10 +37,11 @@ export const updateProjectSummaryHandler = async (
     projectId = projectId.toLowerCase();
     const metadata = await fetchRoundMetadata(chainId as ChainId, roundId);
     const { votingStrategy } = metadata;
-    const votingStrategyName = votingStrategy.strategyName as VotingStrategy;
+    const votingStrategyName =
+      votingStrategy.strategyName as VotingStrategyName;
 
     // throw error if voting strategy is not supported
-    if (votingStrategyName !== VotingStrategy.LINEAR_QUADRATIC_FUNDING) {
+    if (votingStrategyName !== VotingStrategyName.LINEAR_QUADRATIC_FUNDING) {
       throw "error: unsupported voting strategy";
     }
 
@@ -125,7 +126,7 @@ export const getProjectsSummary = async (
         roundId,
         roundMetadata,
         votingStrategyId,
-        projectIds,
+        projectIds
       );
 
       contributions = await hotfixForRounds(roundId, contributions, projectIds);

--- a/packages/api/src/types.ts
+++ b/packages/api/src/types.ts
@@ -51,7 +51,6 @@ export type HandleResponseObject = {
   data: object;
 };
 
-
 /****************/
 /* = Passport = */
 /****************/
@@ -68,7 +67,7 @@ export type PassportResponse = {
   status?: string;
   last_score_timestamp?: string;
   evidence?: PassportEvidence;
-  error?: string|null;
+  error?: string | null;
   detail?: string;
 };
 
@@ -118,21 +117,69 @@ export type QFDistribution = {
   uniqueContributorsCount: number;
 };
 
+/****************/
+/* =  Graph  =  */
+/****************/
+
 export type GraphResponse<T> = {
   data: T;
   error?: any;
-}
+};
+
+export type GraphPrograms = {
+  programs: GraphProgram[];
+};
+
+export type GraphProgram = {
+  id: string;
+  createdAt: string;
+  updatedAt: string;
+  rounds: GraphRound[];
+};
+
+export type GraphRound = {
+  id: string;
+  createdAt: string;
+  updatedAt: string;
+  applicationsStartTime: string;
+  applicationsEndTime: string;
+  roundStartTime: string;
+  roundEndTime: string;
+  payoutStrategy: string;
+  token: string;
+  votingStrategy: GraphVotingStrategy;
+  program: GraphProgram;
+};
+
+export type GraphRounds = {
+  rounds: GraphRound[];
+};
 
 export type GraphVotingStrategy = {
   id: string;
-  version: string;
-  strategyName: string;
   strategyAddress: string;
-}
+  strategyName: string;
+  version: string;
+  round: GraphRound;
+};
 
 export type GraphVotingStrategies = {
   votingStrategies: GraphVotingStrategy[];
-}
+};
+
+export type GraphRoundProject = {
+  createdAt: string;
+  updatedAt: string;
+  id: string;
+  payoutAddress: string;
+  project: string;
+  status: string;
+  round: GraphRound;
+};
+
+export type GraphRoundProjects = {
+  roundProjects: GraphRoundProject[];
+};
 
 export type GraphQFVote = {
   id: string;
@@ -143,14 +190,23 @@ export type GraphQFVote = {
   to: string;
   token: string;
   version: string;
-  votingStrategy: {
-    id: string;
-    round: {
-      id: string;
-    }
-  };
-}
+  votingStrategy: GraphVotingStrategy;
+};
 
 export type GraphQFVotes = {
   qfvotes: GraphQFVote[];
-}
+};
+
+export type GraphBlock = {
+  number: number;
+  timestamp: number;
+  hash: string;
+};
+
+export type GraphMeta = {
+  _meta: {
+    block: GraphBlock;
+    hasIndexingErrors: boolean;
+    deployment: string;
+  };
+};

--- a/packages/api/src/types.ts
+++ b/packages/api/src/types.ts
@@ -117,3 +117,40 @@ export type QFDistribution = {
   projectPayoutAddress: string;
   uniqueContributorsCount: number;
 };
+
+export type GraphResponse<T> = {
+  data: T;
+  error?: any;
+}
+
+export type GraphVotingStrategy = {
+  id: string;
+  version: string;
+  strategyName: string;
+  strategyAddress: string;
+}
+
+export type GraphVotingStrategies = {
+  votingStrategies: GraphVotingStrategy[];
+}
+
+export type GraphQFVote = {
+  id: string;
+  amount: string;
+  createdAt: string;
+  from: string;
+  projectId: string;
+  to: string;
+  token: string;
+  version: string;
+  votingStrategy: {
+    id: string;
+    round: {
+      id: string;
+    }
+  };
+}
+
+export type GraphQFVotes = {
+  qfvotes: GraphQFVote[];
+}


### PR DESCRIPTION
This PR modifies the schema of our database to include a Votes table. 

The table looks like : 
```
  id               Int     
  createdAt        DateTime 
  updatedAt        DateTime 
  roundId          String
  projectId        String
  graphId          String
  voteAmount       String
  voteTimestamp    String
  voterAddress     String
  voteToAddress    String
  voteToken        String
  voteVersion      String
```

The PR also includes a seeding script - which fills the votes (and upserts the project/rounds) table with _all_ votes pulled from the graph. 

Having this data will be very useful. 

**Todo**
- [ ] Figure out if the graph is doing wonky business (the responses from large queries are inconsistent 💀 )
- [x] Add Optimism
- [x] Add Fantom
- [x] Testnets
- [ ] Tests
- [ ] Project Ids and future proofing
- [ ] TBD

After this is complete, we can start refactoring our endpoints to utilize the cached data. 

We will also need a service to watch for new votes and subsequently append votes to the new table as they are emitted. 
