### PR TITLE
Add contract details to Fund Contract tab

### DIFF
--- a/packages/grant-explorer/src/features/api/utils.ts
+++ b/packages/grant-explorer/src/features/api/utils.ts
@@ -247,10 +247,11 @@ const getGraphQLEndpoint = async (chainId: ChainId) => {
 };
 
 /**
- * Fetch subgraph network for provided web3 network
+ * Fetch the correct transaction explorer for the provided web3 network
  *
- * @param chainId - The chain ID of the blockchain2
- * @returns the subgraph endpoint
+ * @param chainId - The chain ID of the blockchain
+ * @param txHash - The transaction hash
+ * @returns the transaction explorer URL for the provided transaction hash and network
  */
 export const getTxExplorer = (chainId?: ChainId, txHash?: string) => {
   switch (chainId) {

--- a/packages/grant-explorer/src/features/api/utils.ts
+++ b/packages/grant-explorer/src/features/api/utils.ts
@@ -16,78 +16,97 @@ export const TokenNamesAndLogos: Record<string, string> = {
   ETH: "./logos/ethereum-eth-logo.svg",
 };
 
+export const TokenAndCoinGeckoIds: Record<string, string> = {
+  FTM: "fantom",
+  BUSD: "binance-usd",
+  DAI: "dai",
+  ETH: "ethereum",
+};
+
 export const payoutTokens = [
   {
     name: "DAI",
     chainId: ChainId.MAINNET,
     address: "0x6B175474E89094C44Da98b954EedeAC495271d0F",
     logo: TokenNamesAndLogos["DAI"],
+    coingeckoId: TokenAndCoinGeckoIds["DAI"],
   },
   {
     name: "ETH",
     chainId: ChainId.MAINNET,
     address: ethers.constants.AddressZero,
     logo: TokenNamesAndLogos["ETH"],
+    coingeckoId: TokenAndCoinGeckoIds["ETH"],
   },
   {
     name: "DAI",
     chainId: ChainId.OPTIMISM_MAINNET_CHAIN_ID,
     address: "0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1",
     logo: TokenNamesAndLogos["DAI"],
+    coingeckoId: TokenAndCoinGeckoIds["DAI"],
   },
   {
     name: "ETH",
     chainId: ChainId.OPTIMISM_MAINNET_CHAIN_ID,
     address: ethers.constants.AddressZero,
     logo: TokenNamesAndLogos["ETH"],
+    coingeckoId: TokenAndCoinGeckoIds["ETH"],
   },
   {
     name: "WFTM",
     chainId: ChainId.FANTOM_MAINNET_CHAIN_ID,
     address: "0x21be370D5312f44cB42ce377BC9b8a0cEF1A4C83",
     logo: TokenNamesAndLogos["FTM"],
+    coingeckoId: TokenAndCoinGeckoIds["FTM"],
   },
   {
     name: "FTM",
     chainId: ChainId.FANTOM_MAINNET_CHAIN_ID,
     address: ethers.constants.AddressZero,
     logo: TokenNamesAndLogos["FTM"],
+    coingeckoId: TokenAndCoinGeckoIds["FTM"],
   },
   {
     name: "BUSD",
     chainId: ChainId.FANTOM_MAINNET_CHAIN_ID,
     address: "0xC931f61B1534EB21D8c11B24f3f5Ab2471d4aB50",
     logo: TokenNamesAndLogos["BUSD"],
+    coingeckoId: TokenAndCoinGeckoIds["BUSD"],
   },
   {
     name: "DAI",
     chainId: ChainId.FANTOM_MAINNET_CHAIN_ID,
     address: "0x8d11ec38a3eb5e956b052f67da8bdc9bef8abf3e",
     logo: TokenNamesAndLogos["DAI"],
+    coingeckoId: TokenAndCoinGeckoIds["DAI"],
   },
   {
     name: "DAI",
     chainId: ChainId.FANTOM_TESTNET_CHAIN_ID,
     address: "0xEdE59D58d9B8061Ff7D22E629AB2afa01af496f4",
     logo: TokenNamesAndLogos["DAI"],
+    coingeckoId: TokenAndCoinGeckoIds["DAI"],
   },
   {
     name: "BUSD",
     chainId: ChainId.GOERLI_CHAIN_ID,
     address: "0xa7c3bf25ffea8605b516cf878b7435fe1768c89b",
     logo: TokenNamesAndLogos["BUSD"],
+    coingeckoId: TokenAndCoinGeckoIds["BUSD"],
   },
   {
     name: "DAI",
     chainId: ChainId.GOERLI_CHAIN_ID,
     address: "0xf2edF1c091f683E3fb452497d9a98A49cBA84666",
     logo: TokenNamesAndLogos["DAI"],
+    coingeckoId: TokenAndCoinGeckoIds["DAI"],
   },
   {
     name: "ETH",
     chainId: ChainId.GOERLI_CHAIN_ID,
     address: ethers.constants.AddressZero,
     logo: TokenNamesAndLogos["ETH"],
+    coingeckoId: TokenAndCoinGeckoIds["ETH"],
   },
 ];
 

--- a/packages/round-manager/src/features/api/round.ts
+++ b/packages/round-manager/src/features/api/round.ts
@@ -51,6 +51,7 @@ export async function getRoundById(
               applicationsEndTime
               roundStartTime
               roundEndTime
+              token
               projectsMetaPtr {
                 pointer
               }

--- a/packages/round-manager/src/features/api/utils.ts
+++ b/packages/round-manager/src/features/api/utils.ts
@@ -541,3 +541,33 @@ export const useTokenPrice = (tokenId: string | undefined) => {
     loading,
   };
 };
+
+/**
+ * Fetch link to contract on Etherscan or other explorer
+ *
+ * @param chainId - The chain ID of the blockchain
+ * @param contractAddress - The address of the contract
+ * @returns The link to the contract on Etherscan or other
+ * explorer for the given chain ID and contract address
+ */
+export const getTxExplorerForContract = (
+  chainId: ChainId,
+  contractAddress: string
+) => {
+  switch (chainId) {
+    case ChainId.OPTIMISM_MAINNET_CHAIN_ID:
+      return `https://optimistic.etherscan.io/address/${contractAddress}`;
+
+    case ChainId.FANTOM_MAINNET_CHAIN_ID:
+      return `https://ftmscan.com/address/${contractAddress}`;
+
+    case ChainId.FANTOM_TESTNET_CHAIN_ID:
+      return `https://testnet.ftmscan.com/address/${contractAddress}`;
+
+    case ChainId.MAINNET:
+      return `https://etherscan.io/address/${contractAddress}`;
+
+    default:
+      return `https://goerli.etherscan.io/address/${contractAddress}`;
+  }
+};

--- a/packages/round-manager/src/features/api/utils.ts
+++ b/packages/round-manager/src/features/api/utils.ts
@@ -1,4 +1,5 @@
 import { ethers } from "ethers";
+import { useMemo, useState } from "react";
 import { ApplicationMetadata, InputType, IPFSObject, Program } from "./types";
 
 export enum ChainId {
@@ -59,78 +60,97 @@ export const TokenNamesAndLogos: Record<string, string> = {
   ETH: "./logos/ethereum-eth-logo.svg",
 };
 
+export const TokenAndCoinGeckoIds: Record<string, string> = {
+  FTM: "fantom",
+  BUSD: "binance-usd",
+  DAI: "dai",
+  ETH: "ethereum",
+};
+
 export const payoutTokens = [
   {
     name: "DAI",
     chainId: ChainId.MAINNET,
     address: "0x6B175474E89094C44Da98b954EedeAC495271d0F",
     logo: TokenNamesAndLogos["DAI"],
+    coingeckoId: TokenAndCoinGeckoIds["DAI"],
   },
   {
     name: "ETH",
     chainId: ChainId.MAINNET,
     address: ethers.constants.AddressZero,
     logo: TokenNamesAndLogos["ETH"],
+    coingeckoId: TokenAndCoinGeckoIds["ETH"],
   },
   {
     name: "DAI",
     chainId: ChainId.OPTIMISM_MAINNET_CHAIN_ID,
     address: "0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1",
     logo: TokenNamesAndLogos["DAI"],
+    coingeckoId: TokenAndCoinGeckoIds["DAI"],
   },
   {
     name: "ETH",
     chainId: ChainId.OPTIMISM_MAINNET_CHAIN_ID,
     address: ethers.constants.AddressZero,
     logo: TokenNamesAndLogos["ETH"],
+    coingeckoId: TokenAndCoinGeckoIds["ETH"],
   },
   {
     name: "WFTM",
     chainId: ChainId.FANTOM_MAINNET_CHAIN_ID,
     address: "0x21be370D5312f44cB42ce377BC9b8a0cEF1A4C83",
     logo: TokenNamesAndLogos["FTM"],
+    coingeckoId: TokenAndCoinGeckoIds["FTM"],
   },
   {
     name: "FTM",
     chainId: ChainId.FANTOM_MAINNET_CHAIN_ID,
     address: ethers.constants.AddressZero,
     logo: TokenNamesAndLogos["FTM"],
+    coingeckoId: TokenAndCoinGeckoIds["FTM"],
   },
   {
     name: "BUSD",
     chainId: ChainId.FANTOM_MAINNET_CHAIN_ID,
     address: "0xC931f61B1534EB21D8c11B24f3f5Ab2471d4aB50",
     logo: TokenNamesAndLogos["BUSD"],
+    coingeckoId: TokenAndCoinGeckoIds["BUSD"],
   },
   {
     name: "DAI",
     chainId: ChainId.FANTOM_MAINNET_CHAIN_ID,
     address: "0x8d11ec38a3eb5e956b052f67da8bdc9bef8abf3e",
     logo: TokenNamesAndLogos["DAI"],
+    coingeckoId: TokenAndCoinGeckoIds["DAI"],
   },
   {
     name: "DAI",
     chainId: ChainId.FANTOM_TESTNET_CHAIN_ID,
     address: "0xEdE59D58d9B8061Ff7D22E629AB2afa01af496f4",
     logo: TokenNamesAndLogos["DAI"],
+    coingeckoId: TokenAndCoinGeckoIds["DAI"],
   },
   {
     name: "BUSD",
     chainId: ChainId.GOERLI_CHAIN_ID,
     address: "0xa7c3bf25ffea8605b516cf878b7435fe1768c89b",
     logo: TokenNamesAndLogos["BUSD"],
+    coingeckoId: TokenAndCoinGeckoIds["BUSD"],
   },
   {
     name: "DAI",
     chainId: ChainId.GOERLI_CHAIN_ID,
     address: "0xf2edF1c091f683E3fb452497d9a98A49cBA84666",
     logo: TokenNamesAndLogos["DAI"],
+    coingeckoId: TokenAndCoinGeckoIds["DAI"],
   },
   {
     name: "ETH",
     chainId: ChainId.GOERLI_CHAIN_ID,
     address: ethers.constants.AddressZero,
     logo: TokenNamesAndLogos["ETH"],
+    coingeckoId: TokenAndCoinGeckoIds["ETH"],
   },
 ];
 
@@ -481,3 +501,43 @@ export function typeToText(s: string) {
   if (s == "checkbox") return "Checkboxes";
   return (s.charAt(0).toUpperCase() + s.slice(1)).replace("-", " ");
 }
+
+export const useTokenPrice = (tokenId: string | undefined) => {
+  const [tokenPrice, setTokenPrice] = useState<number>();
+  const [error, setError] = useState<Response | undefined>();
+  const [loading, setLoading] = useState(false);
+
+  useMemo(() => {
+    setLoading(true);
+    const tokenPriceEndpoint = `https://api.coingecko.com/api/v3/simple/price?ids=${tokenId}&vs_currencies=usd`;
+    fetch(tokenPriceEndpoint, {
+      headers: {
+        method: "GET",
+        Accept: "application/json",
+      },
+    })
+      .then((resp) => {
+        if (resp.ok) {
+          return resp.json();
+        } else {
+          setError(resp);
+          setLoading(false);
+        }
+      })
+      .then((data) => {
+        if (data) {
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+          const { usd } = data[tokenId!];
+          setTokenPrice(usd);
+        } else {
+          setError(data.message);
+        }
+        setLoading(false);
+      });
+  }, [tokenId]);
+  return {
+    data: tokenPrice,
+    error,
+    loading,
+  };
+};

--- a/packages/round-manager/src/features/api/utils.ts
+++ b/packages/round-manager/src/features/api/utils.ts
@@ -59,6 +59,81 @@ export const TokenNamesAndLogos: Record<string, string> = {
   ETH: "./logos/ethereum-eth-logo.svg",
 };
 
+export const payoutTokens = [
+  {
+    name: "DAI",
+    chainId: ChainId.MAINNET,
+    address: "0x6B175474E89094C44Da98b954EedeAC495271d0F",
+    logo: TokenNamesAndLogos["DAI"],
+  },
+  {
+    name: "ETH",
+    chainId: ChainId.MAINNET,
+    address: ethers.constants.AddressZero,
+    logo: TokenNamesAndLogos["ETH"],
+  },
+  {
+    name: "DAI",
+    chainId: ChainId.OPTIMISM_MAINNET_CHAIN_ID,
+    address: "0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1",
+    logo: TokenNamesAndLogos["DAI"],
+  },
+  {
+    name: "ETH",
+    chainId: ChainId.OPTIMISM_MAINNET_CHAIN_ID,
+    address: ethers.constants.AddressZero,
+    logo: TokenNamesAndLogos["ETH"],
+  },
+  {
+    name: "WFTM",
+    chainId: ChainId.FANTOM_MAINNET_CHAIN_ID,
+    address: "0x21be370D5312f44cB42ce377BC9b8a0cEF1A4C83",
+    logo: TokenNamesAndLogos["FTM"],
+  },
+  {
+    name: "FTM",
+    chainId: ChainId.FANTOM_MAINNET_CHAIN_ID,
+    address: ethers.constants.AddressZero,
+    logo: TokenNamesAndLogos["FTM"],
+  },
+  {
+    name: "BUSD",
+    chainId: ChainId.FANTOM_MAINNET_CHAIN_ID,
+    address: "0xC931f61B1534EB21D8c11B24f3f5Ab2471d4aB50",
+    logo: TokenNamesAndLogos["BUSD"],
+  },
+  {
+    name: "DAI",
+    chainId: ChainId.FANTOM_MAINNET_CHAIN_ID,
+    address: "0x8d11ec38a3eb5e956b052f67da8bdc9bef8abf3e",
+    logo: TokenNamesAndLogos["DAI"],
+  },
+  {
+    name: "DAI",
+    chainId: ChainId.FANTOM_TESTNET_CHAIN_ID,
+    address: "0xEdE59D58d9B8061Ff7D22E629AB2afa01af496f4",
+    logo: TokenNamesAndLogos["DAI"],
+  },
+  {
+    name: "BUSD",
+    chainId: ChainId.GOERLI_CHAIN_ID,
+    address: "0xa7c3bf25ffea8605b516cf878b7435fe1768c89b",
+    logo: TokenNamesAndLogos["BUSD"],
+  },
+  {
+    name: "DAI",
+    chainId: ChainId.GOERLI_CHAIN_ID,
+    address: "0xf2edF1c091f683E3fb452497d9a98A49cBA84666",
+    logo: TokenNamesAndLogos["DAI"],
+  },
+  {
+    name: "ETH",
+    chainId: ChainId.GOERLI_CHAIN_ID,
+    address: ethers.constants.AddressZero,
+    logo: TokenNamesAndLogos["ETH"],
+  },
+];
+
 export const getPayoutTokenOptions = (chainId: ChainId): PayoutToken[] => {
   switch (chainId) {
     case ChainId.MAINNET: {

--- a/packages/round-manager/src/features/round/FundContract.tsx
+++ b/packages/round-manager/src/features/round/FundContract.tsx
@@ -1,6 +1,6 @@
 import { InformationCircleIcon } from "@heroicons/react/solid";
 import { Round } from "../api/types";
-import { payoutTokens } from "../api/utils";
+import { payoutTokens, useTokenPrice } from "../api/utils";
 
 export default function FundContract(props: {
   round: Round | undefined;
@@ -14,7 +14,14 @@ export default function FundContract(props: {
         t.address.toLocaleLowerCase() == props.round?.token?.toLocaleLowerCase()
     )[0];
 
-  console.log(props.round?.token);
+  const { data, error, loading } = useTokenPrice(
+    matchingFundPayoutToken?.coingeckoId
+  );
+  const matchingFunds =
+    props.round &&
+    props.round.roundMetadata.matchingFunds?.matchingFundsAvailable;
+  const matchingFundsInUSD =
+    matchingFunds && data && !loading && !error && matchingFunds * Number(data);
 
   return (
     <div className="mt-8">
@@ -57,9 +64,10 @@ export default function FundContract(props: {
         <div className="flex flex-row justify-start mt-6">
           <p className="text-sm w-1/3">Matching pool size:</p>
           <p className="text-sm">
-            {props.round?.roundMetadata?.matchingFunds?.matchingFundsAvailable}{" "}
-            {matchingFundPayoutToken?.name}{" "}
-            <span className="text-sm text-slate-400 ml-6">$1234.00 USD</span>
+            {matchingFunds} {matchingFundPayoutToken?.name}{" "}
+            <span className="text-sm text-slate-400 ml-2">
+              ${matchingFundsInUSD} USD
+            </span>
           </p>
         </div>
         <div className="flex flex-row justify-start mt-6">
@@ -84,7 +92,7 @@ export default function FundContract(props: {
           <p className="text-sm w-1/3">Amount in contract:</p>
           <p className="text-sm">
             11000 {matchingFundPayoutToken?.name}{" "}
-            <span className="text-sm text-slate-400 ml-6">$1234.00 USD</span>
+            <span className="text-sm text-slate-400 ml-2">$1234.00 USD</span>
           </p>
         </div>
         <hr className="mt-6 mb-6" />

--- a/packages/round-manager/src/features/round/FundContract.tsx
+++ b/packages/round-manager/src/features/round/FundContract.tsx
@@ -7,6 +7,7 @@ import {
   payoutTokens,
   useTokenPrice,
 } from "../api/utils";
+import { Spinner } from "../common/Spinner";
 
 export default function FundContract(props: {
   round: Round | undefined;
@@ -46,7 +47,13 @@ export default function FundContract(props: {
     data &&
     !loading &&
     !error &&
+    !isBalanceError &&
+    !isBalanceLoading &&
     Number(balanceData?.formatted) * Number(data);
+
+  if (props.round === undefined || isBalanceLoading || loading) {
+    return <Spinner text="Loading..." />;
+  }
 
   return (
     <div className="mt-8">

--- a/packages/round-manager/src/features/round/FundContract.tsx
+++ b/packages/round-manager/src/features/round/FundContract.tsx
@@ -22,7 +22,7 @@ export default function FundContract(props: {
     )[0];
 
   const tokenDetail = {
-    addressOrName: props.roundId!,
+    addressOrName: props.roundId,
     token: matchingFundPayoutToken?.address,
   };
 
@@ -151,7 +151,7 @@ export default function FundContract(props: {
               window.open(
                 getTxExplorerForContract(
                   props.chainId as unknown as ChainId,
-                  props.roundId!
+                  props.roundId as string
                 ),
                 "_blank"
               )

--- a/packages/round-manager/src/features/round/FundContract.tsx
+++ b/packages/round-manager/src/features/round/FundContract.tsx
@@ -1,4 +1,5 @@
 import { InformationCircleIcon } from "@heroicons/react/solid";
+import { useBalance } from "wagmi";
 import { Round } from "../api/types";
 import {
   ChainId,
@@ -19,14 +20,35 @@ export default function FundContract(props: {
         t.address.toLocaleLowerCase() == props.round?.token?.toLocaleLowerCase()
     )[0];
 
+  const tokenDetail = {
+    addressOrName: props.roundId!,
+    token: matchingFundPayoutToken?.address,
+  };
+
+  const {
+    data: balanceData,
+    isError: isBalanceError,
+    isLoading: isBalanceLoading,
+  } = useBalance(tokenDetail);
+
   const { data, error, loading } = useTokenPrice(
     matchingFundPayoutToken?.coingeckoId
   );
+
+  console.log("DASA matchingFundPayoutToken", matchingFundPayoutToken);
+
   const matchingFunds =
     props.round &&
     props.round.roundMetadata.matchingFunds?.matchingFundsAvailable;
   const matchingFundsInUSD =
     matchingFunds && data && !loading && !error && matchingFunds * Number(data);
+
+  const tokenBalanceInUSD =
+    balanceData?.value &&
+    data &&
+    !loading &&
+    !error &&
+    Number(balanceData?.formatted) * Number(data);
 
   return (
     <div className="mt-8">
@@ -96,8 +118,10 @@ export default function FundContract(props: {
         <div className="flex flex-row justify-start mt-6">
           <p className="text-sm w-1/3">Amount in contract:</p>
           <p className="text-sm">
-            11000 {matchingFundPayoutToken?.name}{" "}
-            <span className="text-sm text-slate-400 ml-2">$1234.00 USD</span>
+            {balanceData?.formatted} {matchingFundPayoutToken?.name}{" "}
+            <span className="text-sm text-slate-400 ml-2">
+              ${tokenBalanceInUSD} USD
+            </span>
           </p>
         </div>
         <hr className="mt-6 mb-6" />

--- a/packages/round-manager/src/features/round/FundContract.tsx
+++ b/packages/round-manager/src/features/round/FundContract.tsx
@@ -2,6 +2,7 @@ import { Spinner } from "../common/Spinner";
 import React, { useEffect, useState } from "react";
 import { XIcon } from "@heroicons/react/outline";
 import { Round } from "../api/types";
+import { InformationCircleIcon } from "@heroicons/react/solid";
 
 export default function FundContract(props: {
   round: Round | undefined;
@@ -18,19 +19,70 @@ export default function FundContract(props: {
       </p>
       <p className="font-bold text-sm">Contract Details</p>
       <hr className="mt-2 mb-4" />
-      <p className="text-sm text-grey-400">
+      <p className="text-sm text-grey-400 mb-4">
         You must fund the smart contract with the matching pool amount you
         pledged during round creation. However, you are always welcome to fund
         over the initial amount if you wish to do so.
       </p>
-      <div className="mt-2">
-        <p className="text-sm text-black-400 mt-6">Contract Address:</p>
-        <p className="text-sm text-black-400 mt-6">Payout Token:</p>
-        <p className="text-sm text-black-400 mt-6">Matching pool size:</p>
-        <p className="text-sm text-black-400 mt-6">Protocol Fee:</p>
-        <p className="text-sm text-black-400 mt-6">Round fee:</p>
-        <p className="text-sm text-black-400 mt-6">Amount in contract:</p>
-      </div>
+      <table className="mb-12">
+        <tr>
+          <td className="flex flex-row">
+            Contract Address:
+            <span>
+              <InformationIcon />
+            </span>
+          </td>
+          <td>{props.round?.id}</td>
+        </tr>
+        <tr>
+          <td>Payout token:</td>
+          <td>{props.round?.token}</td>
+        </tr>
+        <tr>
+          <td>Matching pool size:</td>
+          <td>
+            {props.round?.roundMetadata?.matchingFunds?.matchingFundsAvailable}
+          </td>
+        </tr>
+        <tr>
+          <td className="flex flex-row">
+            Protocol fee:
+            <InformationIcon />
+          </td>
+          <td>10%</td>
+        </tr>
+        <tr>
+          <td className="flex flex-row">
+            Round fee:
+            <InformationIcon />
+          </td>
+          <td>10%</td>
+        </tr>
+        <tr>
+          <td>Amount in contract:</td>
+          <td>0</td>
+        </tr>
+        <hr />
+        <tr>
+          <td className="flex flex-row">
+            Final day to fund:
+            <InformationIcon />
+          </td>
+          <td>{props.round?.roundEndTime.toString()}</td>
+        </tr>
+        <tr>
+          <td>Amount left to fund:</td>
+          <td>10,000</td>
+        </tr>
+        <tr>
+          <td>Amount to fund:</td>
+          <td>10,000</td>
+        </tr>
+      </table>
     </div>
   );
+}
+
+function InformationIcon() {
+  return <InformationCircleIcon className="mt-1 ml-1 text-gray-900 w-4 h-4" />;
 }

--- a/packages/round-manager/src/features/round/FundContract.tsx
+++ b/packages/round-manager/src/features/round/FundContract.tsx
@@ -1,26 +1,20 @@
 import { InformationCircleIcon } from "@heroicons/react/solid";
 import { Round } from "../api/types";
+import { payoutTokens } from "../api/utils";
 
 export default function FundContract(props: {
   round: Round | undefined;
   chainId: string;
   roundId: string | undefined;
 }) {
-  function getTimeLeft(roundEndTime: Date | undefined): string {
-    if (!roundEndTime) {
-      return "";
-    }
-    const dateDiffInSecs = (roundEndTime.getTime() || 0) - Date.now();
-    const daysLeft = Math.floor(dateDiffInSecs / (1000 * 60 * 60 * 24));
-    const hoursLeft = Math.floor(
-      (dateDiffInSecs % (1000 * 60 * 60 * 24)) / (1000 * 60 * 60)
-    );
-    const minutesLeft = Math.floor(
-      (dateDiffInSecs % (1000 * 60 * 60)) / (1000 * 60)
-    );
-    const secondsLeft = Math.floor((dateDiffInSecs % (1000 * 60)) / 1000);
-    return `${daysLeft}d ${hoursLeft}h ${minutesLeft}m ${secondsLeft}s`;
-  }
+  const matchingFundPayoutToken =
+    props.round &&
+    payoutTokens.filter(
+      (t) =>
+        t.address.toLocaleLowerCase() == props.round?.token?.toLocaleLowerCase()
+    )[0];
+
+  console.log(props.round?.token);
 
   return (
     <div className="mt-8">
@@ -39,62 +33,69 @@ export default function FundContract(props: {
       </p>
       <div className="flex flex-col mt-4 max-w-xl">
         <div className="flex flex-row justify-start">
-          <p className="text-sm w-1/3">
-            Contract Address: <InformationIcon />
+          <p className="flex flex-row text-sm w-1/3">
+            Contract Address:
+            <span>
+              <InformationIcon />
+            </span>
           </p>
           <p className="text-sm">{props.round?.id}</p>
         </div>
         <div className="flex flex-row justify-start mt-6">
           <p className="text-sm w-1/3">Payout token:</p>
-          <p className="text-sm">{props.round?.token}</p>
+          <p className="flex flex-row text-sm">
+            {matchingFundPayoutToken?.logo ? (
+              <img
+                src={matchingFundPayoutToken.logo}
+                alt=""
+                className="h-6 w-6 flex-shrink-0 rounded-full"
+              />
+            ) : null}
+            <span className="ml-2 pt-0.5">{matchingFundPayoutToken?.name}</span>
+          </p>
         </div>
         <div className="flex flex-row justify-start mt-6">
           <p className="text-sm w-1/3">Matching pool size:</p>
           <p className="text-sm">
             {props.round?.roundMetadata?.matchingFunds?.matchingFundsAvailable}{" "}
-            {props.round?.token}{" "}
+            {matchingFundPayoutToken?.name}{" "}
             <span className="text-sm text-slate-400 ml-6">$1234.00 USD</span>
           </p>
         </div>
         <div className="flex flex-row justify-start mt-6">
-          <p className="text-sm w-1/3">
-            Protocol fee: <InformationIcon />
+          <p className="flex flex-row text-sm w-1/3">
+            Protocol fee:
+            <span>
+              <InformationIcon />
+            </span>
           </p>
-          <p className="text-sm">10%</p>
+          <p className="text-sm">0%</p>
         </div>
         <div className="flex flex-row justify-start mt-6">
-          <p className="text-sm w-1/3">
-            Round fee: <InformationIcon />
+          <p className="flex flex-row text-sm w-1/3">
+            Round fee:
+            <span>
+              <InformationIcon />
+            </span>
           </p>
-          <p className="text-sm">10%</p>
+          <p className="text-sm">0%</p>
         </div>
         <div className="flex flex-row justify-start mt-6">
           <p className="text-sm w-1/3">Amount in contract:</p>
           <p className="text-sm">
-            11000 {props.round?.token}{" "}
+            11000 {matchingFundPayoutToken?.name}{" "}
             <span className="text-sm text-slate-400 ml-6">$1234.00 USD</span>
           </p>
         </div>
         <hr className="mt-6 mb-6" />
-        <div className="flex flex-row justify-start">
-          <p className="text-sm w-1/3">
-            Final day to fund: <InformationIcon />
-          </p>
-          <p className="text-sm">
-            {props.round?.roundEndTime.toLocaleString()}{" "}
-            <span className="text-sm text-red-500 ml-6">
-              ({getTimeLeft(props.round?.roundEndTime)})
-            </span>
-          </p>
-        </div>
         <div className="flex flex-row justify-start mt-6">
           <p className="text-sm w-1/3">Amount left to fund:</p>
-          <p className="text-sm">0 {props.round?.token}</p>
+          <p className="text-sm">0 {matchingFundPayoutToken?.name}</p>
         </div>
         <div className="flex flex-row justify-start mt-6">
-          <p className="text-sm w-1/3">Amount to fund:</p>
+          <p className="text-sm w-1/3 py-3">Amount to fund:</p>
           <input
-            className="border border-gray-300 rounded-md p-2"
+            className="border border-gray-300 rounded-md p-2 w-1/2"
             placeholder="Enter the amount you wish to fund"
           />
         </div>
@@ -102,7 +103,7 @@ export default function FundContract(props: {
           <button className="bg-violet-400 hover:bg-violet-700 text-white py-2 px-4 rounded">
             Fund Contract
           </button>
-          <button className="bg-white hover:bg-blue-700 text-gray py-2 px-4 rounded border border-gray ml-4">
+          <button className="bg-white hover:text-violet-700 hover:border-violet-700 text-gray py-2 px-4 rounded border border-gray ml-4">
             View Contract
           </button>
         </div>

--- a/packages/round-manager/src/features/round/FundContract.tsx
+++ b/packages/round-manager/src/features/round/FundContract.tsx
@@ -1,4 +1,5 @@
 import { InformationCircleIcon } from "@heroicons/react/solid";
+import ReactTooltip from "react-tooltip";
 import { useBalance } from "wagmi";
 import { Round } from "../api/types";
 import {
@@ -75,7 +76,22 @@ export default function FundContract(props: {
           <p className="flex flex-row text-sm w-1/3">
             Contract Address:
             <span>
-              <InformationIcon />
+              <InformationIcon
+                dataFor="contract-tooltip"
+                dataTestId="contract-tooltip"
+              />
+              <ReactTooltip
+                id="contract-tooltip"
+                place="bottom"
+                type="dark"
+                effect="solid"
+              >
+                <p className="text-xs">
+                  This is the contract address of your round's core
+                  <br />
+                  contract.
+                </p>
+              </ReactTooltip>
             </span>
           </p>
           <p className="text-sm">{props.round?.id}</p>
@@ -106,7 +122,28 @@ export default function FundContract(props: {
           <p className="flex flex-row text-sm w-1/3">
             Protocol fee:
             <span>
-              <InformationIcon />
+              <InformationIcon
+                dataFor="protocol-fee-tooltip"
+                dataTestId="protocol-fee-tooltip"
+              />
+              <ReactTooltip
+                id="protocol-fee-tooltip"
+                place="bottom"
+                type="dark"
+                effect="solid"
+              >
+                <p className="text-xs">
+                  Allo Protocol can be configured to charge fees
+                  <br />
+                  for use. These fees are paid to GitcoinDAO, who
+                  <br />
+                  use the funds to fund public goods. If enabled,
+                  <br />
+                  the fee is calculated as a percentage of your
+                  <br />
+                  funding pool, added on top of your pool.
+                </p>
+              </ReactTooltip>
             </span>
           </p>
           <p className="text-sm">0%</p>
@@ -115,7 +152,28 @@ export default function FundContract(props: {
           <p className="flex flex-row text-sm w-1/3">
             Round fee:
             <span>
-              <InformationIcon />
+              <InformationIcon
+                dataFor="round-fee-tooltip"
+                dataTestId="round-fee-tooltip"
+              />
+              <ReactTooltip
+                id="round-fee-tooltip"
+                place="bottom"
+                type="dark"
+                effect="solid"
+              >
+                <p className="text-xs">
+                  The round fees are any additional charges
+                  <br />
+                  for services used to run your round. These
+                  <br />
+                  can be software services (i.e. this user interface)
+                  <br />
+                  or other specialty tools. If enabled, they are
+                  <br />
+                  calculated as a percentage of your funding pool.
+                </p>
+              </ReactTooltip>
             </span>
           </p>
           <p className="text-sm">0%</p>
@@ -165,6 +223,14 @@ export default function FundContract(props: {
   );
 }
 
-function InformationIcon() {
-  return <InformationCircleIcon className="mt-1 ml-1 text-gray-900 w-4 h-4" />;
+function InformationIcon(props: { dataFor: string; dataTestId: string }) {
+  return (
+    <InformationCircleIcon
+      className="mt-1 ml-1 text-gray-900 w-3 h-3"
+      data-tip
+      data-background-color="#0E0333"
+      data-for={props.dataFor}
+      data-testid={props.dataTestId}
+    />
+  );
 }

--- a/packages/round-manager/src/features/round/FundContract.tsx
+++ b/packages/round-manager/src/features/round/FundContract.tsx
@@ -1,6 +1,11 @@
 import { InformationCircleIcon } from "@heroicons/react/solid";
 import { Round } from "../api/types";
-import { payoutTokens, useTokenPrice } from "../api/utils";
+import {
+  ChainId,
+  getTxExplorerForContract,
+  payoutTokens,
+  useTokenPrice,
+} from "../api/utils";
 
 export default function FundContract(props: {
   round: Round | undefined;
@@ -111,7 +116,18 @@ export default function FundContract(props: {
           <button className="bg-violet-400 hover:bg-violet-700 text-white py-2 px-4 rounded">
             Fund Contract
           </button>
-          <button className="bg-white hover:text-violet-700 hover:border-violet-700 text-gray py-2 px-4 rounded border border-gray ml-4">
+          <button
+            className="bg-white hover:text-violet-700 hover:border-violet-700 text-gray py-2 px-4 rounded border border-gray ml-4"
+            onClick={() =>
+              window.open(
+                getTxExplorerForContract(
+                  props.chainId as unknown as ChainId,
+                  props.roundId!
+                ),
+                "_blank"
+              )
+            }
+          >
             View Contract
           </button>
         </div>

--- a/packages/round-manager/src/features/round/FundContract.tsx
+++ b/packages/round-manager/src/features/round/FundContract.tsx
@@ -213,11 +213,15 @@ export default function FundContract(props: {
           />
         </div>
         <div className="flex flex-row justify-start mt-6">
-          <button className="bg-violet-400 hover:bg-violet-700 text-white py-2 px-4 rounded">
+          <button
+            className="bg-violet-400 hover:bg-violet-700 text-white py-2 px-4 rounded"
+            data-testid="fund-contract-btn"
+          >
             Fund Contract
           </button>
           <button
             className="bg-white hover:text-violet-700 hover:border-violet-700 text-gray py-2 px-4 rounded border border-gray ml-4"
+            data-testid="view-contract-btn"
             onClick={() =>
               window.open(
                 getTxExplorerForContract(

--- a/packages/round-manager/src/features/round/FundContract.tsx
+++ b/packages/round-manager/src/features/round/FundContract.tsx
@@ -1,14 +1,27 @@
-import { Spinner } from "../common/Spinner";
-import React, { useEffect, useState } from "react";
-import { XIcon } from "@heroicons/react/outline";
-import { Round } from "../api/types";
 import { InformationCircleIcon } from "@heroicons/react/solid";
+import { Round } from "../api/types";
 
 export default function FundContract(props: {
   round: Round | undefined;
   chainId: string;
   roundId: string | undefined;
 }) {
+  function getTimeLeft(roundEndTime: Date | undefined): string {
+    if (!roundEndTime) {
+      return "";
+    }
+    const dateDiffInSecs = (roundEndTime.getTime() || 0) - Date.now();
+    const daysLeft = Math.floor(dateDiffInSecs / (1000 * 60 * 60 * 24));
+    const hoursLeft = Math.floor(
+      (dateDiffInSecs % (1000 * 60 * 60 * 24)) / (1000 * 60 * 60)
+    );
+    const minutesLeft = Math.floor(
+      (dateDiffInSecs % (1000 * 60 * 60)) / (1000 * 60)
+    );
+    const secondsLeft = Math.floor((dateDiffInSecs % (1000 * 60)) / 1000);
+    return `${daysLeft}d ${hoursLeft}h ${minutesLeft}m ${secondsLeft}s`;
+  }
+
   return (
     <div className="mt-8">
       <p
@@ -24,61 +37,79 @@ export default function FundContract(props: {
         pledged during round creation. However, you are always welcome to fund
         over the initial amount if you wish to do so.
       </p>
-      <table className="mb-12">
-        <tr>
-          <td className="flex flex-row">
-            Contract Address:
-            <span>
-              <InformationIcon />
+      <div className="flex flex-col mt-4 max-w-xl">
+        <div className="flex flex-row justify-start">
+          <p className="text-sm w-1/3">
+            Contract Address:{" "}
+            <InformationCircleIcon className="h-3 w-3 ml-1 inline" />
+          </p>
+          <p className="text-sm">{props.round?.id}</p>
+        </div>
+        <div className="flex flex-row justify-start mt-6">
+          <p className="text-sm w-1/3">Payout token:</p>
+          <p className="text-sm">{props.round?.token}</p>
+        </div>
+        <div className="flex flex-row justify-start mt-6">
+          <p className="text-sm w-1/3">Matching pool size:</p>
+          <p className="text-sm">
+            {props.round?.roundMetadata?.matchingFunds?.matchingFundsAvailable}{" "}
+            {props.round?.token}{" "}
+            <span className="text-sm text-slate-400 ml-6">$1234.00 USD</span>
+          </p>
+        </div>
+        <div className="flex flex-row justify-start mt-6">
+          <p className="text-sm w-1/3">
+            Protocol fee:{" "}
+            <InformationCircleIcon className="h-3 w-3 ml-1 inline" />
+          </p>
+          <p className="text-sm">10%</p>
+        </div>
+        <div className="flex flex-row justify-start mt-6">
+          <p className="text-sm w-1/3">
+            Round fee: <InformationCircleIcon className="h-3 w-3 ml-1 inline" />
+          </p>
+          <p className="text-sm">10%</p>
+        </div>
+        <div className="flex flex-row justify-start mt-6">
+          <p className="text-sm w-1/3">Amount in contract:</p>
+          <p className="text-sm">
+            11000 {props.round?.token}{" "}
+            <span className="text-sm text-slate-400 ml-6">$1234.00 USD</span>
+          </p>
+        </div>
+        <hr className="mt-6 mb-6" />
+        <div className="flex flex-row justify-start">
+          <p className="text-sm w-1/3">
+            Final day to fund:{" "}
+            <InformationCircleIcon className="h-3 w-3 ml-1 inline" />
+          </p>
+          <p className="text-sm">
+            {props.round?.roundEndTime.toLocaleString()}{" "}
+            <span className="text-sm text-red-500 ml-6">
+              ({getTimeLeft(props.round?.roundEndTime)})
             </span>
-          </td>
-          <td>{props.round?.id}</td>
-        </tr>
-        <tr>
-          <td>Payout token:</td>
-          <td>{props.round?.token}</td>
-        </tr>
-        <tr>
-          <td>Matching pool size:</td>
-          <td>
-            {props.round?.roundMetadata?.matchingFunds?.matchingFundsAvailable}
-          </td>
-        </tr>
-        <tr>
-          <td className="flex flex-row">
-            Protocol fee:
-            <InformationIcon />
-          </td>
-          <td>10%</td>
-        </tr>
-        <tr>
-          <td className="flex flex-row">
-            Round fee:
-            <InformationIcon />
-          </td>
-          <td>10%</td>
-        </tr>
-        <tr>
-          <td>Amount in contract:</td>
-          <td>0</td>
-        </tr>
-        <hr />
-        <tr>
-          <td className="flex flex-row">
-            Final day to fund:
-            <InformationIcon />
-          </td>
-          <td>{props.round?.roundEndTime.toString()}</td>
-        </tr>
-        <tr>
-          <td>Amount left to fund:</td>
-          <td>10,000</td>
-        </tr>
-        <tr>
-          <td>Amount to fund:</td>
-          <td>10,000</td>
-        </tr>
-      </table>
+          </p>
+        </div>
+        <div className="flex flex-row justify-start mt-6">
+          <p className="text-sm w-1/3">Amount left to fund:</p>
+          <p className="text-sm">0 {props.round?.token}</p>
+        </div>
+        <div className="flex flex-row justify-start mt-6">
+          <p className="text-sm w-1/3">Amount to fund:</p>
+          <input
+            className="border border-gray-300 rounded-md p-2"
+            placeholder="Enter the amount you wish to fund"
+          />
+        </div>
+        <div className="flex flex-row justify-start mt-6">
+          <button className="bg-violet-400 hover:bg-violet-700 text-white py-2 px-4 rounded">
+            Fund Contract
+          </button>
+          <button className="bg-white hover:bg-blue-700 text-gray py-2 px-4 rounded border border-gray ml-4">
+            View Contract
+          </button>
+        </div>
+      </div>
     </div>
   );
 }

--- a/packages/round-manager/src/features/round/FundContract.tsx
+++ b/packages/round-manager/src/features/round/FundContract.tsx
@@ -8,5 +8,29 @@ export default function FundContract(props: {
   chainId: string;
   roundId: string | undefined;
 }) {
-  return <div>Fund Contract</div>;
+  return (
+    <div className="mt-8">
+      <p
+        className="font-bold mb-10 text-base"
+        data-testid="fund-contract-title"
+      >
+        Fund Contract
+      </p>
+      <p className="font-bold text-sm">Contract Details</p>
+      <hr className="mt-2 mb-4" />
+      <p className="text-sm text-grey-400">
+        You must fund the smart contract with the matching pool amount you
+        pledged during round creation. However, you are always welcome to fund
+        over the initial amount if you wish to do so.
+      </p>
+      <div className="mt-2">
+        <p className="text-sm text-black-400 mt-6">Contract Address:</p>
+        <p className="text-sm text-black-400 mt-6">Payout Token:</p>
+        <p className="text-sm text-black-400 mt-6">Matching pool size:</p>
+        <p className="text-sm text-black-400 mt-6">Protocol Fee:</p>
+        <p className="text-sm text-black-400 mt-6">Round fee:</p>
+        <p className="text-sm text-black-400 mt-6">Amount in contract:</p>
+      </div>
+    </div>
+  );
 }

--- a/packages/round-manager/src/features/round/FundContract.tsx
+++ b/packages/round-manager/src/features/round/FundContract.tsx
@@ -1,0 +1,12 @@
+import { Spinner } from "../common/Spinner";
+import React, { useEffect, useState } from "react";
+import { XIcon } from "@heroicons/react/outline";
+import { Round } from "../api/types";
+
+export default function FundContract(props: {
+  round: Round | undefined;
+  chainId: string;
+  roundId: string | undefined;
+}) {
+  return <div>Fund Contract</div>;
+}

--- a/packages/round-manager/src/features/round/FundContract.tsx
+++ b/packages/round-manager/src/features/round/FundContract.tsx
@@ -40,8 +40,15 @@ export default function FundContract(props: {
   const matchingFunds =
     props.round &&
     props.round.roundMetadata.matchingFunds?.matchingFundsAvailable;
+
   const matchingFundsInUSD =
     matchingFunds && data && !loading && !error && matchingFunds * Number(data);
+
+  const amountLeftToFund =
+    matchingFunds && matchingFunds - Number(balanceData?.formatted);
+
+  const amountLeftToFundInUSD =
+    amountLeftToFund && amountLeftToFund * Number(data);
 
   const tokenBalanceInUSD =
     balanceData?.value &&
@@ -190,7 +197,13 @@ export default function FundContract(props: {
         <hr className="mt-6 mb-6" />
         <div className="flex flex-row justify-start mt-6">
           <p className="text-sm w-1/3">Amount left to fund:</p>
-          <p className="text-sm">0 {matchingFundPayoutToken?.name}</p>
+          <p className="text-sm">
+            {" "}
+            {amountLeftToFund} {matchingFundPayoutToken?.name}{" "}
+            <span className="text-sm text-slate-400 ml-2">
+              ${amountLeftToFundInUSD} USD
+            </span>
+          </p>
         </div>
         <div className="flex flex-row justify-start mt-6">
           <p className="text-sm w-1/3 py-3">Amount to fund:</p>

--- a/packages/round-manager/src/features/round/FundContract.tsx
+++ b/packages/round-manager/src/features/round/FundContract.tsx
@@ -40,8 +40,7 @@ export default function FundContract(props: {
       <div className="flex flex-col mt-4 max-w-xl">
         <div className="flex flex-row justify-start">
           <p className="text-sm w-1/3">
-            Contract Address:{" "}
-            <InformationCircleIcon className="h-3 w-3 ml-1 inline" />
+            Contract Address: <InformationIcon />
           </p>
           <p className="text-sm">{props.round?.id}</p>
         </div>
@@ -59,14 +58,13 @@ export default function FundContract(props: {
         </div>
         <div className="flex flex-row justify-start mt-6">
           <p className="text-sm w-1/3">
-            Protocol fee:{" "}
-            <InformationCircleIcon className="h-3 w-3 ml-1 inline" />
+            Protocol fee: <InformationIcon />
           </p>
           <p className="text-sm">10%</p>
         </div>
         <div className="flex flex-row justify-start mt-6">
           <p className="text-sm w-1/3">
-            Round fee: <InformationCircleIcon className="h-3 w-3 ml-1 inline" />
+            Round fee: <InformationIcon />
           </p>
           <p className="text-sm">10%</p>
         </div>
@@ -80,8 +78,7 @@ export default function FundContract(props: {
         <hr className="mt-6 mb-6" />
         <div className="flex flex-row justify-start">
           <p className="text-sm w-1/3">
-            Final day to fund:{" "}
-            <InformationCircleIcon className="h-3 w-3 ml-1 inline" />
+            Final day to fund: <InformationIcon />
           </p>
           <p className="text-sm">
             {props.round?.roundEndTime.toLocaleString()}{" "}

--- a/packages/round-manager/src/features/round/FundContract.tsx
+++ b/packages/round-manager/src/features/round/FundContract.tsx
@@ -35,8 +35,6 @@ export default function FundContract(props: {
     matchingFundPayoutToken?.coingeckoId
   );
 
-  console.log("DASA matchingFundPayoutToken", matchingFundPayoutToken);
-
   const matchingFunds =
     props.round &&
     props.round.roundMetadata.matchingFunds?.matchingFundsAvailable;

--- a/packages/round-manager/src/features/round/ViewRoundPage.tsx
+++ b/packages/round-manager/src/features/round/ViewRoundPage.tsx
@@ -9,6 +9,7 @@ import {
   InboxIcon,
   ChartBarIcon,
   DocumentReportIcon,
+  DocumentTextIcon,
 } from "@heroicons/react/solid";
 import { Tab } from "@headlessui/react";
 import ApplicationsReceived from "./ApplicationsReceived";
@@ -32,6 +33,7 @@ import {
 import { Button } from "common/src/styles";
 import { ReactComponent as GrantExplorerLogo } from "../../assets/grantexplorer-icon.svg";
 import ViewRoundResults from "./ViewRoundResults";
+import FundContract from "./FundContract";
 import ViewRoundStats from "./ViewRoundStats";
 import { getUTCDate, getUTCTime } from "../api/utils";
 
@@ -177,6 +179,25 @@ export default function ViewRoundPage() {
                           </div>
                         )}
                       </Tab>
+                      <Tab className={({ selected }) => tabStyles(selected)}>
+                        {({ selected }) => (
+                          <div
+                            className={
+                              selected
+                                ? "text-black-500 flex flex-row"
+                                : "flex flex-row"
+                            }
+                          >
+                            <DocumentTextIcon className="h-6 w-6 mr-2" />
+                            <span
+                              className="mt-0.5"
+                              data-testid="round-results"
+                            >
+                              Fund Contract
+                            </span>
+                          </div>
+                        )}
+                      </Tab>
                     </Tab.List>
                   </div>
                   <Tab.Panels className="basis-5/6 ml-6">
@@ -197,6 +218,13 @@ export default function ViewRoundPage() {
                     </Tab.Panel>
                     <Tab.Panel>
                       <ViewRoundResults
+                        round={round}
+                        chainId={`${chain.id}`}
+                        roundId={id}
+                      />
+                    </Tab.Panel>
+                    <Tab.Panel>
+                      <FundContract
                         round={round}
                         chainId={`${chain.id}`}
                         roundId={id}

--- a/packages/round-manager/src/features/round/ViewRoundPage.tsx
+++ b/packages/round-manager/src/features/round/ViewRoundPage.tsx
@@ -31,7 +31,7 @@ import {
 } from "../api/types";
 import { Button } from "common/src/styles";
 import { ReactComponent as GrantExplorerLogo } from "../../assets/grantexplorer-icon.svg";
-import ViewFundingAdmin from "./ViewFundingAdmin";
+import ViewRoundResults from "./ViewRoundResults";
 import ViewRoundStats from "./ViewRoundStats";
 import { getUTCDate, getUTCTime } from "../api/utils";
 
@@ -170,9 +170,9 @@ export default function ViewRoundPage() {
                             <DocumentReportIcon className="h-6 w-6 mr-2" />
                             <span
                               className="mt-0.5"
-                              data-testid="funding-admin"
+                              data-testid="round-results"
                             >
-                              Funding Admin
+                              Round Results
                             </span>
                           </div>
                         )}
@@ -196,7 +196,7 @@ export default function ViewRoundPage() {
                       />
                     </Tab.Panel>
                     <Tab.Panel>
-                      <ViewFundingAdmin
+                      <ViewRoundResults
                         round={round}
                         chainId={`${chain.id}`}
                         roundId={id}

--- a/packages/round-manager/src/features/round/ViewRoundPage.tsx
+++ b/packages/round-manager/src/features/round/ViewRoundPage.tsx
@@ -156,7 +156,7 @@ export default function ViewRoundPage() {
                             <DocumentTextIcon className="h-6 w-6 mr-2" />
                             <span
                               className="mt-0.5"
-                              data-testid="round-results"
+                              data-testid="fund-contract"
                             >
                               Fund Contract
                             </span>

--- a/packages/round-manager/src/features/round/ViewRoundPage.tsx
+++ b/packages/round-manager/src/features/round/ViewRoundPage.tsx
@@ -1,41 +1,41 @@
-import { useEffect, useState } from "react";
-import { Link, useParams } from "react-router-dom";
-import { useWallet } from "../common/Auth";
-import Navbar from "../common/Navbar";
+import { datadogLogs } from "@datadog/browser-logs";
+import { Tab } from "@headlessui/react";
 import {
   CalendarIcon,
+  ChartBarIcon,
   ChevronRightIcon,
   ClockIcon,
-  InboxIcon,
-  ChartBarIcon,
   DocumentReportIcon,
   DocumentTextIcon,
+  InboxIcon,
 } from "@heroicons/react/solid";
-import { Tab } from "@headlessui/react";
-import ApplicationsReceived from "./ApplicationsReceived";
-import ApplicationsApproved from "./ApplicationsApproved";
-import ApplicationsRejected from "./ApplicationsRejected";
-import Footer from "../common/Footer";
+import { Button } from "common/src/styles";
+import { useEffect, useState } from "react";
+import { Link, useParams } from "react-router-dom";
 import tw from "tailwind-styled-components";
-import { datadogLogs } from "@datadog/browser-logs";
-import NotFoundPage from "../common/NotFoundPage";
-import AccessDenied from "../common/AccessDenied";
-import CopyToClipboardButton from "../common/CopyToClipboardButton";
-import { useRoundById } from "../../context/round/RoundContext";
-import { Spinner } from "../common/Spinner";
+import { ReactComponent as GrantExplorerLogo } from "../../assets/grantexplorer-icon.svg";
 import { useApplicationByRoundId } from "../../context/application/ApplicationContext";
+import { useRoundById } from "../../context/round/RoundContext";
 import {
   ApplicationStatus,
   GrantApplication,
   ProgressStatus,
   Round,
 } from "../api/types";
-import { Button } from "common/src/styles";
-import { ReactComponent as GrantExplorerLogo } from "../../assets/grantexplorer-icon.svg";
-import ViewRoundResults from "./ViewRoundResults";
-import FundContract from "./FundContract";
-import ViewRoundStats from "./ViewRoundStats";
 import { getUTCDate, getUTCTime } from "../api/utils";
+import AccessDenied from "../common/AccessDenied";
+import { useWallet } from "../common/Auth";
+import CopyToClipboardButton from "../common/CopyToClipboardButton";
+import Footer from "../common/Footer";
+import Navbar from "../common/Navbar";
+import NotFoundPage from "../common/NotFoundPage";
+import { Spinner } from "../common/Spinner";
+import ApplicationsApproved from "./ApplicationsApproved";
+import ApplicationsReceived from "./ApplicationsReceived";
+import ApplicationsRejected from "./ApplicationsRejected";
+import FundContract from "./FundContract";
+import ViewRoundResults from "./ViewRoundResults";
+import ViewRoundStats from "./ViewRoundStats";
 
 export default function ViewRoundPage() {
   datadogLogs.logger.info("====> Route: /round/:id");
@@ -153,6 +153,25 @@ export default function ViewRoundPage() {
                                 : "flex flex-row"
                             }
                           >
+                            <DocumentTextIcon className="h-6 w-6 mr-2" />
+                            <span
+                              className="mt-0.5"
+                              data-testid="round-results"
+                            >
+                              Fund Contract
+                            </span>
+                          </div>
+                        )}
+                      </Tab>
+                      <Tab className={({ selected }) => tabStyles(selected)}>
+                        {({ selected }) => (
+                          <div
+                            className={
+                              selected
+                                ? "text-black-500 flex flex-row"
+                                : "flex flex-row"
+                            }
+                          >
                             <ChartBarIcon className="h-6 w-6 mr-2" />
                             <span className="mt-0.5" data-testid="round-stats">
                               Round Stats
@@ -179,25 +198,6 @@ export default function ViewRoundPage() {
                           </div>
                         )}
                       </Tab>
-                      <Tab className={({ selected }) => tabStyles(selected)}>
-                        {({ selected }) => (
-                          <div
-                            className={
-                              selected
-                                ? "text-black-500 flex flex-row"
-                                : "flex flex-row"
-                            }
-                          >
-                            <DocumentTextIcon className="h-6 w-6 mr-2" />
-                            <span
-                              className="mt-0.5"
-                              data-testid="round-results"
-                            >
-                              Fund Contract
-                            </span>
-                          </div>
-                        )}
-                      </Tab>
                     </Tab.List>
                   </div>
                   <Tab.Panels className="basis-5/6 ml-6">
@@ -211,6 +211,13 @@ export default function ViewRoundPage() {
                       />
                     </Tab.Panel>
                     <Tab.Panel>
+                      <FundContract
+                        round={round}
+                        chainId={`${chain.id}`}
+                        roundId={id}
+                      />
+                    </Tab.Panel>
+                    <Tab.Panel>
                       <ViewRoundStats
                         roundStats=""
                         isRoundStatsFetched={true}
@@ -218,13 +225,6 @@ export default function ViewRoundPage() {
                     </Tab.Panel>
                     <Tab.Panel>
                       <ViewRoundResults
-                        round={round}
-                        chainId={`${chain.id}`}
-                        roundId={id}
-                      />
-                    </Tab.Panel>
-                    <Tab.Panel>
-                      <FundContract
                         round={round}
                         chainId={`${chain.id}`}
                         roundId={id}

--- a/packages/round-manager/src/features/round/ViewRoundResults.tsx
+++ b/packages/round-manager/src/features/round/ViewRoundResults.tsx
@@ -26,7 +26,7 @@ import {
 } from "../../context/round/FinalizeRoundContext";
 import { errorModalDelayMs } from "../../constants";
 
-export default function ViewFundingAdmin(props: {
+export default function ViewRoundResults(props: {
   round: Round | undefined;
   chainId: string;
   roundId: string | undefined;

--- a/packages/round-manager/src/features/round/__tests__/FundContract.test.tsx
+++ b/packages/round-manager/src/features/round/__tests__/FundContract.test.tsx
@@ -1,0 +1,95 @@
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
+import { fireEvent, render, screen } from "@testing-library/react";
+import ViewRoundPage from "../ViewRoundPage";
+import { ProgressStatus, Round } from "../../api/types";
+import {
+  makeRoundData,
+  wrapWithApplicationContext,
+  wrapWithBulkUpdateGrantApplicationContext,
+  wrapWithReadProgramContext,
+  wrapWithRoundContext,
+} from "../../../test-utils";
+import { useBalance, useDisconnect, useSwitchNetwork } from "wagmi";
+import { useParams } from "react-router-dom";
+import { useTokenPrice } from "../../api/utils";
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { TextDecoder } = require("util");
+global.TextDecoder = TextDecoder;
+
+jest.mock("../../common/Auth");
+jest.mock("wagmi");
+
+jest.mock("@rainbow-me/rainbowkit", () => ({
+  ConnectButton: jest.fn(),
+}));
+
+let mockRoundData: Round = makeRoundData();
+
+jest.mock("react-router-dom", () => ({
+  ...jest.requireActual("react-router-dom"),
+  useParams: jest.fn(),
+}));
+
+jest.mock("../../common/Auth", () => ({
+  useWallet: () => ({
+    chain: {},
+    address: mockRoundData.operatorWallets![0],
+    provider: { getNetwork: () => ({ chainId: "0" }) },
+  }),
+}));
+
+jest.mock("../../api/utils", () => ({
+  ...jest.requireActual("../../api/utils"),
+  useTokenPrice: jest.fn(),
+}));
+
+describe("fund contract tab", () => {
+  beforeEach(() => {
+    (useParams as jest.Mock).mockImplementation(() => {
+      return {
+        id: mockRoundData.id,
+      };
+    });
+
+    (useSwitchNetwork as jest.Mock).mockReturnValue({ chains: [] });
+    (useDisconnect as jest.Mock).mockReturnValue({});
+  });
+
+  it("displays fund contract tab", async () => {
+    mockRoundData = makeRoundData();
+
+    (useTokenPrice as jest.Mock).mockImplementation(() => ({
+      data: "100",
+      error: null,
+      loading: false,
+    }));
+
+    (useBalance as jest.Mock).mockImplementation(() => ({
+      data: { formatted: "0", value: "0" },
+      error: null,
+      loading: false,
+    }));
+
+    render(
+      wrapWithBulkUpdateGrantApplicationContext(
+        wrapWithApplicationContext(
+          wrapWithReadProgramContext(
+            wrapWithRoundContext(<ViewRoundPage />, {
+              data: [mockRoundData],
+              fetchRoundStatus: ProgressStatus.IS_SUCCESS,
+            }),
+            { programs: [] }
+          ),
+          {
+            applications: [],
+            isLoading: false,
+          }
+        )
+      )
+    );
+    const fundContractTab = screen.getByTestId("fund-contract");
+    fireEvent.click(fundContractTab);
+    expect(screen.getByText("Contract Details")).toBeInTheDocument();
+  });
+});

--- a/packages/round-manager/src/features/round/__tests__/FundContract.test.tsx
+++ b/packages/round-manager/src/features/round/__tests__/FundContract.test.tsx
@@ -91,5 +91,13 @@ describe("fund contract tab", () => {
     const fundContractTab = screen.getByTestId("fund-contract");
     fireEvent.click(fundContractTab);
     expect(screen.getByText("Contract Details")).toBeInTheDocument();
+    expect(screen.getByText("Contract Address:")).toBeInTheDocument();
+    expect(screen.getByText("Payout token:")).toBeInTheDocument();
+    expect(screen.getByText("Matching pool size:")).toBeInTheDocument();
+    expect(screen.getByText("Protocol fee:")).toBeInTheDocument();
+    expect(screen.getByText("Round fee:")).toBeInTheDocument();
+    expect(screen.getByText("Amount in contract:")).toBeInTheDocument();
+    expect(screen.getByTestId("fund-contract-btn")).toBeInTheDocument();
+    expect(screen.getByTestId("view-contract-btn")).toBeInTheDocument();
   });
 });

--- a/packages/round-manager/src/features/round/__tests__/ViewRoundPage.test.tsx
+++ b/packages/round-manager/src/features/round/__tests__/ViewRoundPage.test.tsx
@@ -166,7 +166,7 @@ describe("View Round", () => {
     expect(screen.getByTestId("side-nav-bar")).toBeInTheDocument();
     expect(screen.getByText("Grant Applications")).toBeInTheDocument();
     expect(screen.getByText("Round Stats")).toBeInTheDocument();
-    expect(screen.getByText("Funding Admin")).toBeInTheDocument();
+    expect(screen.getByText("Round Results")).toBeInTheDocument();
   });
 
   it("indicates how many of each kind of application there are", () => {

--- a/packages/round-manager/src/features/round/__tests__/ViewRoundResults.test.tsx
+++ b/packages/round-manager/src/features/round/__tests__/ViewRoundResults.test.tsx
@@ -55,7 +55,7 @@ jest.mock("../../common/Auth", () => ({
   }),
 }));
 
-describe("View Funding Admin before distribution data is finalized to contract", () => {
+describe("View Round Results before distribution data is finalized to contract", () => {
   beforeEach(() => {
     (useParams as jest.Mock).mockImplementation(() => {
       return {
@@ -67,7 +67,7 @@ describe("View Funding Admin before distribution data is finalized to contract",
     (useDisconnect as jest.Mock).mockReturnValue({});
   });
 
-  describe("display funding admin tab", () => {
+  describe("display round results tab", () => {
     it("displays No Information Available before round end date", async () => {
       const roundEndTime = faker.date.future();
       mockRoundData = makeRoundData({ roundEndTime });
@@ -88,8 +88,8 @@ describe("View Funding Admin before distribution data is finalized to contract",
           )
         )
       );
-      const fundingAdminTab = screen.getByTestId("funding-admin");
-      fireEvent.click(fundingAdminTab);
+      const roundResultsTab = screen.getByTestId("round-results");
+      fireEvent.click(roundResultsTab);
       expect(screen.getByText("No Information Available")).toBeInTheDocument();
     });
 
@@ -138,8 +138,8 @@ describe("View Funding Admin before distribution data is finalized to contract",
           )
         )
       );
-      const fundingAdminTab = screen.getByTestId("funding-admin");
-      fireEvent.click(fundingAdminTab);
+      const roundResultsTab = screen.getByTestId("round-results");
+      fireEvent.click(roundResultsTab);
       expect(screen.getByTestId("match-stats-title")).toBeInTheDocument();
       expect(screen.getByTestId("matching-stats-table")).toBeInTheDocument();
       expect(screen.getByTestId("finalize-round")).toBeInTheDocument();
@@ -194,8 +194,8 @@ describe("View Funding Admin before distribution data is finalized to contract",
         )
       )
     );
-    const fundingAdminTab = screen.getByTestId("funding-admin");
-    fireEvent.click(fundingAdminTab);
+    const roundResultsTab = screen.getByTestId("round-results");
+    fireEvent.click(roundResultsTab);
     expect(screen.getByTestId("match-stats-title")).toBeInTheDocument();
     expect(screen.getByTestId("matching-stats-table")).toBeInTheDocument();
     expect(screen.getByTestId("custom-or-default-test-id")).toBeInTheDocument();
@@ -279,8 +279,8 @@ describe("View Funding Admin before distribution data is finalized to contract",
         )
       )
     );
-    const fundingAdminTab = screen.getByTestId("funding-admin");
-    fireEvent.click(fundingAdminTab);
+    const roundResultsTab = screen.getByTestId("round-results");
+    fireEvent.click(roundResultsTab);
     expect(screen.getByTestId("match-stats-title")).toBeInTheDocument();
     expect(screen.getByTestId("matching-stats-table")).toBeInTheDocument();
     expect(screen.getByTestId("custom-or-default-test-id")).toBeInTheDocument();
@@ -370,8 +370,8 @@ describe("View Funding Admin before distribution data is finalized to contract",
         )
       )
     );
-    const fundingAdminTab = screen.getByTestId("funding-admin");
-    fireEvent.click(fundingAdminTab);
+    const roundResultsTab = screen.getByTestId("round-results");
+    fireEvent.click(roundResultsTab);
     expect(screen.getByTestId("match-stats-title")).toBeInTheDocument();
     expect(screen.getByTestId("matching-stats-table")).toBeInTheDocument();
     expect(screen.getByTestId("custom-or-default-test-id")).toBeInTheDocument();
@@ -430,8 +430,8 @@ describe("View Funding Admin before distribution data is finalized to contract",
           )
         )
       );
-      const fundingAdminTab = screen.getByTestId("funding-admin");
-      fireEvent.click(fundingAdminTab);
+      const roundResultsTab = screen.getByTestId("round-results");
+      fireEvent.click(roundResultsTab);
       expect(
         screen.getByRole("button", {
           name: /finalize and save to contract/i,
@@ -474,8 +474,8 @@ describe("View Funding Admin before distribution data is finalized to contract",
           )
         )
       );
-      const fundingAdminTab = screen.getByTestId("funding-admin");
-      fireEvent.click(fundingAdminTab);
+      const roundResultsTab = screen.getByTestId("round-results");
+      fireEvent.click(roundResultsTab);
       const button = screen.getByRole("button", {
         name: /finalize and save to contract/i,
       });
@@ -522,8 +522,8 @@ describe("View Funding Admin before distribution data is finalized to contract",
           )
         )
       );
-      const fundingAdminTab = screen.getByTestId("funding-admin");
-      fireEvent.click(fundingAdminTab);
+      const roundResultsTab = screen.getByTestId("round-results");
+      fireEvent.click(roundResultsTab);
       const finalizeButton = screen.getByRole("button", {
         name: /finalize and save to contract/i,
       });
@@ -540,7 +540,7 @@ describe("View Funding Admin before distribution data is finalized to contract",
   });
 });
 
-describe("View Funding Admin after distribution data is finalized to contract", () => {
+describe("View Round Results after distribution data is finalized to contract", () => {
   beforeEach(() => {
     (useParams as jest.Mock).mockImplementation(() => {
       return {
@@ -597,8 +597,8 @@ describe("View Funding Admin after distribution data is finalized to contract", 
         )
       )
     );
-    const fundingAdminTab = screen.getByTestId("funding-admin");
-    fireEvent.click(fundingAdminTab);
+    const roundResultsTab = screen.getByTestId("round-results");
+    fireEvent.click(roundResultsTab);
     expect(screen.getByTestId("finalized-round")).toBeInTheDocument();
     expect(screen.getByTestId("match-stats-title")).toBeInTheDocument();
     expect(screen.getByTestId("matching-stats-table")).toBeInTheDocument();


### PR DESCRIPTION
<!-- 
Thank you for your pull request! Please review the requirements below 
and ensure your pull request has fulfilled all requirements outlined in the target package.
-->

##### Description

As a program manager
I want to see the funding pool details of my round
So that I can reference them during operations

Acceptance Criteria

- [x] Rename current "Funding Admin" tab to "Round Results"
- [x] Add a new tab for "Fund Contract"
- [x] Display contract/round info as per [figma](https://www.figma.com/file/V113F2Pp5m2qDM5odXjfFu/Manager-S17?node-id=208%3A16341&t=flkAYfWJH8i2T4Ua-4)
- [x] Add "View contract" link to etherscan
- [x] Add amount in contract value (also in USD)
- [x] Add loading state & loading spinner. Show loading spinner till data from contract & coingecko are loaded
- [x] Add tooltips
- [x] Tests

##### Refers/Fixes

fixes #1146 

##### Testing

<!-- All PRs should be accompanied by tests! If you haven't added tests, please explain here. -->
