### PR TITLE
wip: add tooltip to project form and paragraph answers

### DIFF
--- a/packages/builder/src/components/grants/inputs.tsx
+++ b/packages/builder/src/components/grants/inputs.tsx
@@ -1,4 +1,4 @@
-import { Tooltip } from "@chakra-ui/react";
+import { Link, Tooltip } from "@chakra-ui/react";
 import { InformationCircleIcon } from "@heroicons/react/24/solid";
 import classNames from "classnames";
 import { ethers } from "ethers";
@@ -310,14 +310,14 @@ export function TextArea({
     <span>
       We now offer rich text support with Markdown. To learn more about how to
       use Markdown, check out{" "}
-      <a
+      <Link
         href="https://www.markdownguide.org/cheat-sheet/"
         target="_blank"
         rel="noreferrer"
         className="cursor-pointer underline"
       >
         this guide
-      </a>
+      </Link>
       .
     </span>
   );
@@ -334,15 +334,23 @@ export function TextArea({
           {required ? requiredSpan : optionalSpan}
         </div>
         {encrypted && encryptionTooltip}
-        <Tooltip
-          hasArrow
-          closeOnClick
-          bg="purple.900"
-          className="shrink ml-2 cursor-pointer"
-          label={markdownTooltipText}
+        {/*  */}
+        <Link
+          href="https://www.markdownguide.org/cheat-sheet/"
+          target="_blank"
+          rel="noreferrer"
+          className="cursor-pointer underline"
         >
-          <InformationCircleIcon className="w-6 h-6" color="gray" />
-        </Tooltip>
+          <Tooltip
+            hasArrow
+            closeOnClick
+            bg="purple.900"
+            className="shrink ml-2 cursor-pointer"
+            label={markdownTooltipText}
+          >
+            <InformationCircleIcon className="w-6 h-6" color="gray" />
+          </Tooltip>
+        </Link>
       </div>
       <legend>{info}</legend>
       <textarea

--- a/packages/builder/src/components/grants/inputs.tsx
+++ b/packages/builder/src/components/grants/inputs.tsx
@@ -2,7 +2,7 @@ import { Link, Tooltip } from "@chakra-ui/react";
 import { InformationCircleIcon } from "@heroicons/react/24/solid";
 import classNames from "classnames";
 import { ethers } from "ethers";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import {
   AddressInputProps,
   InputProps,
@@ -297,6 +297,7 @@ export function TextArea({
   containerClass,
   rows,
 }: TextAreaProps) {
+  const [markdownToolTipOpen, setMarkdownToolTipOpen] = useState(false);
   let borderClass = "";
   let feedbackColor = "";
 
@@ -307,7 +308,13 @@ export function TextArea({
   }
 
   const markdownTooltipText = (
-    <span>
+    <div
+      style={{ pointerEvents: "auto" }}
+      onMouseEnter={() => setMarkdownToolTipOpen(true)}
+      onMouseLeave={() => setMarkdownToolTipOpen(false)}
+      onFocus={() => setMarkdownToolTipOpen(true)}
+      onBlur={() => setMarkdownToolTipOpen(false)}
+    >
       We now offer rich text support with Markdown. To learn more about how to
       use Markdown, check out{" "}
       <Link
@@ -319,7 +326,7 @@ export function TextArea({
         this guide
       </Link>
       .
-    </span>
+    </div>
   );
 
   return (
@@ -335,11 +342,12 @@ export function TextArea({
         </div>
         {encrypted && encryptionTooltip}
         {/*  */}
-        <Link
-          href="https://www.markdownguide.org/cheat-sheet/"
-          target="_blank"
-          rel="noreferrer"
-          className="cursor-pointer underline"
+        <span
+          onMouseEnter={() => setMarkdownToolTipOpen(true)}
+          onMouseLeave={() => setMarkdownToolTipOpen(false)}
+          onFocus={() => setMarkdownToolTipOpen(true)}
+          onBlur={() => setMarkdownToolTipOpen(false)}
+          style={{ paddingBottom: "3px" }}
         >
           <Tooltip
             hasArrow
@@ -347,10 +355,12 @@ export function TextArea({
             bg="purple.900"
             className="shrink ml-2 cursor-pointer"
             label={markdownTooltipText}
+            isOpen={markdownToolTipOpen}
+            onOpen={() => setMarkdownToolTipOpen(true)}
           >
             <InformationCircleIcon className="w-6 h-6" color="gray" />
           </Tooltip>
-        </Link>
+        </span>
       </div>
       <legend>{info}</legend>
       <textarea

--- a/packages/builder/src/components/grants/inputs.tsx
+++ b/packages/builder/src/components/grants/inputs.tsx
@@ -3,13 +3,13 @@ import { InformationCircleIcon } from "@heroicons/react/24/solid";
 import classNames from "classnames";
 import { ethers } from "ethers";
 import { useEffect } from "react";
-import { getAddressType } from "../../utils/utils";
 import {
   AddressInputProps,
   InputProps,
-  TextAreaProps,
   ProjectOption,
+  TextAreaProps,
 } from "../../types";
+import { getAddressType } from "../../utils/utils";
 
 const optionalSpan = (
   <span className="text-gray-400 inset-y-0 right-0 text-sm">Optional</span>
@@ -193,7 +193,9 @@ export function TextInputAddress({
             encrypted ? `${encryptionTooltipLabel} \n` : ""
           } ${tooltipValue}`}
         >
-          <InformationCircleIcon className="w-6 h-6" color="gray" />
+          <span>
+            <InformationCircleIcon className="w-6 h-6" color="gray" />
+          </span>
         </Tooltip>
       </div>
       <legend>{info}</legend>
@@ -304,6 +306,22 @@ export function TextArea({
     feedbackColor = styleInfo.feedbackColor;
   }
 
+  const markdownTooltipText = (
+    <span>
+      We now offer rich text support with Markdown. To learn more about how to
+      use Markdown, check out{" "}
+      <a
+        href="https://www.markdownguide.org/cheat-sheet/"
+        target="_blank"
+        rel="noreferrer"
+        className="cursor-pointer underline"
+      >
+        this guide
+      </a>
+      .
+    </span>
+  );
+
   return (
     <div className={`mt-6 w-full sm:max-w-md relative ${containerClass}`}>
       <div className="flex">
@@ -316,6 +334,15 @@ export function TextArea({
           {required ? requiredSpan : optionalSpan}
         </div>
         {encrypted && encryptionTooltip}
+        <Tooltip
+          hasArrow
+          closeOnClick
+          bg="purple.900"
+          className="shrink ml-2 cursor-pointer"
+          label={markdownTooltipText}
+        >
+          <InformationCircleIcon className="w-6 h-6" color="gray" />
+        </Tooltip>
       </div>
       <legend>{info}</legend>
       <textarea


### PR DESCRIPTION
##### Description

This adds a tooltip to the project application description for markdown support and also to the question answers that are paragraph type.

##### Refers/Fixes

Closes #1209 

![Screenshot 2023-03-21 at 9 53 03 AM](https://user-images.githubusercontent.com/9419140/226664493-8bb85ead-c824-4924-bfba-90ae815e45a1.png)
