### PR TITLE
make sure undefined is an empty string for answer text

### DIFF
--- a/packages/builder/src/components/application/Form.tsx
+++ b/packages/builder/src/components/application/Form.tsx
@@ -261,7 +261,7 @@ function FullPreview(props: {
                   const currentAnswer = answers[question.id];
                   const answerText = Array.isArray(currentAnswer)
                     ? currentAnswer.join(", ")
-                    : currentAnswer;
+                    : currentAnswer || "";
 
                   return (
                     <div>


### PR DESCRIPTION
See Discord thread: https://discord.com/channels/562828676480237578/1095761375751569512

Fixes the non-required fields to not be undefined and an empty string instead when the user does not answer the question.