### PR TITLE
Fix Builder Image Sizes

### DIFF
--- a/packages/builder/src/components/base/ImageInput.tsx
+++ b/packages/builder/src/components/base/ImageInput.tsx
@@ -201,7 +201,7 @@ export default function ImageInput({
         dimensions={dimensions}
         onClose={() => setShowCrop(false)}
         saveCrop={(imgUrl) => {
-          imgUrl.toBlob((blob) => blob && imgHandler(blob));
+          imgUrl.toBlob((blob) => blob && imgHandler(blob), "image/jpeg", 0.9);
         }}
       />
     </div>

--- a/packages/builder/src/components/base/ProjectForm.tsx
+++ b/packages/builder/src/components/base/ProjectForm.tsx
@@ -176,8 +176,8 @@ function ProjectForm({
         <ImageInput
           label="Project Logo"
           dimensions={{
-            width: 300,
-            height: 300,
+            width: 600,
+            height: 600,
           }}
           circle
           imageHash={props.formMetaData.logoImg}

--- a/packages/builder/src/components/base/ProjectForm.tsx
+++ b/packages/builder/src/components/base/ProjectForm.tsx
@@ -176,8 +176,8 @@ function ProjectForm({
         <ImageInput
           label="Project Logo"
           dimensions={{
-            width: 600,
-            height: 600,
+            width: 400,
+            height: 400,
           }}
           circle
           imageHash={props.formMetaData.logoImg}

--- a/packages/builder/src/components/base/images/ImageCrop.tsx
+++ b/packages/builder/src/components/base/images/ImageCrop.tsx
@@ -67,7 +67,7 @@ export default function ImageCrop({
   useEffect(() => {
     if (completedCrop?.width && completedCrop?.height && imgRef.current) {
       // We use canvasPreview as it's much faster than imgPreview.
-      const canvas = buildCanvas(imgRef.current, completedCrop);
+      const canvas = buildCanvas(imgRef.current, completedCrop, dimensions);
       setCroppedCanvas(canvas);
     }
   }, [completedCrop]);

--- a/packages/builder/src/components/base/images/buildCanvas.ts
+++ b/packages/builder/src/components/base/images/buildCanvas.ts
@@ -1,12 +1,9 @@
 import { PixelCrop } from "react-image-crop";
 
-const TO_RADIANS = Math.PI / 180;
-
 export default function buildCanvas(
   image: HTMLImageElement,
   crop: PixelCrop,
-  scale = 1,
-  rotate = 0
+  dimensions: { width: number; height: number }
 ) {
   const canvas = document.createElement("canvas");
 
@@ -18,48 +15,22 @@ export default function buildCanvas(
 
   const scaleX = image.naturalWidth / image.width;
   const scaleY = image.naturalHeight / image.height;
-  // devicePixelRatio slightly increases sharpness on retina devices
-  // at the expense of slightly slower render times and needing to
-  // size the image back down if you want to download/upload and be
-  // true to the images natural size.
-  const pixelRatio = window.devicePixelRatio;
-  // const pixelRatio = 1
 
-  canvas.width = Math.floor(crop.width * scaleX * pixelRatio);
-  canvas.height = Math.floor(crop.height * scaleY * pixelRatio);
+  canvas.width = dimensions.width;
+  canvas.height = dimensions.height;
 
-  ctx.scale(pixelRatio, pixelRatio);
   ctx.imageSmoothingQuality = "high";
 
-  const cropX = crop.x * scaleX;
-  const cropY = crop.y * scaleY;
-
-  const rotateRads = rotate * TO_RADIANS;
-  const centerX = image.naturalWidth / 2;
-  const centerY = image.naturalHeight / 2;
-
-  ctx.save();
-
-  // 5) Move the crop origin to the canvas origin (0,0)
-  ctx.translate(-cropX, -cropY);
-  // 4) Move the origin to the center of the original position
-  ctx.translate(centerX, centerY);
-  // 3) Rotate around the origin
-  ctx.rotate(rotateRads);
-  // 2) Scale the image
-  ctx.scale(scale, scale);
-  // 1) Move the center of the image to the origin (0,0)
-  ctx.translate(-centerX, -centerY);
   ctx.drawImage(
     image,
+    crop.x * scaleX,
+    crop.y * scaleY,
+    crop.width * scaleX,
+    crop.height * scaleY,
     0,
     0,
-    image.naturalWidth,
-    image.naturalHeight,
-    0,
-    0,
-    image.naturalWidth,
-    image.naturalHeight
+    canvas.width,
+    canvas.height
   );
 
   return canvas;


### PR DESCRIPTION
<!-- 
Thank you for your pull request! Please review the requirements below 
and ensure your pull request has fulfilled all requirements outlined in the target package.
-->

##### Description

- Simplify the image cropping code
- Apply a resize to avoid uploading huge images
- Use JPEG instead of PNG for a x5 image size reduction

This PR + changing our IPFS gateway to our CDN (https://ipfs-grants-stack.gitcoin.co) should reduce our costs to almost nothing.

In the future we can also optimize and convert images to other formats (like webp) on the fly based on the user agent, we can do this with Cloudfront.

More discussion here:

https://github.com/gitcoinco/grants-stack/issues/1395
https://github.com/gitcoinco/grants-stack/discussions/1129

<!-- Describe your changes here. -->

##### Refers/Fixes

<!-- If this PR is related to a GitHub issue, please add a link here. -->

##### Testing

<!-- All PRs should be accompanied by tests! If you haven't added tests, please explain here. -->
