### PR TITLE
Twitter and Github Verification Fixes

### DIFF
--- a/packages/builder/src/components/grants/Landing.tsx
+++ b/packages/builder/src/components/grants/Landing.tsx
@@ -80,7 +80,7 @@ function Landing() {
     if (queryCode) {
       channel.postMessage({
         target: "twitter",
-        data: { code: queryCode, state: queryState },
+        data: { error: queryError, code: queryCode, state: queryState },
       });
     }
     // always close the redirected window
@@ -101,7 +101,7 @@ function Landing() {
     if (queryCode) {
       channel.postMessage({
         target: "github",
-        data: { code: queryCode, state: queryState },
+        data: { error: queryError, code: queryCode, state: queryState },
       });
     }
 

--- a/packages/builder/src/components/providers/Github.tsx
+++ b/packages/builder/src/components/providers/Github.tsx
@@ -3,16 +3,19 @@ import { Tooltip } from "@chakra-ui/react";
 import { datadogLogs } from "@datadog/browser-logs";
 import { datadogRum } from "@datadog/browser-rum";
 import { QuestionMarkCircleIcon } from "@heroicons/react/24/solid";
-import { useEffect, useState } from "react";
 import { shallowEqual, useDispatch, useSelector } from "react-redux";
-import { BroadcastChannel } from "broadcast-channel";
-import { debounce } from "ts-debounce";
 import { global } from "../../global";
 // --- Identity tools
 import { RootState } from "../../reducers";
 import { CredentialProvider } from "../../types";
 import Button, { ButtonVariants } from "../base/Button";
-import { ClientType, fetchVerifiableCredential } from "./identity";
+import {
+  openOauthWindow,
+  ClientType,
+  fetchVerifiableCredential,
+  VerificationError,
+  VerifiableCredential,
+} from "./identity/credentials";
 import { credentialsSaved } from "../../actions/projectForm";
 import useValidateCredential from "../../hooks/useValidateCredential";
 import VerifiedBadge from "../badges/VerifiedBadge";
@@ -41,133 +44,87 @@ export default function Github({
     (state: RootState) => ({
       account: state.web3.account,
       formMetaData: state.projectForm.metadata,
-      vc: state.projectForm?.credentials?.github,
+      verifiableCredential: state.projectForm?.credentials?.github,
     }),
     shallowEqual
   );
   const { signer } = global;
   const dispatch = useDispatch();
-  const [GHID, setGHID] = useState("");
 
   const { isValid: validGithubCredential } = useValidateCredential(
-    props.vc,
+    props.verifiableCredential,
     CredentialProvider.Github,
     props.formMetaData.projectGithub
   );
 
-  // Fetch Github OAuth2 url from the IAM procedure
-  async function handleFetchGithubOAuth(): Promise<void> {
-    const width = 600;
-    const height = 800;
-    // eslint-disable-next-line no-restricted-globals
-    const left = screen.width / 2 - width / 2;
-    // eslint-disable-next-line no-restricted-globals
-    const top = screen.height / 2 - height / 2;
-    // Generate a new state string and store it in the compoenents state so that we can
-    // verify it later
-    const ghID = `github-${generateUID(10)}`;
-
-    setGHID(ghID);
-
-    // Pass data to the page via props
-    const authWindow = window.open(
-      "",
-      "_blank",
+  async function handleVerify(): Promise<void> {
+    // Fetch data from external API
+    try {
+      const ghID = `github-${generateUID(10)}`;
       // eslint-disable-next-line max-len
-      `toolbar=no, location=no, directories=no, status=no, menubar=no, resizable=no, copyhistory=no, width=${width}, height=${height}, top=${top}, left=${left}`
-    );
+      const authUrl = `https://github.com/login/oauth/authorize?client_id=${process.env.REACT_APP_PUBLIC_GITHUB_CLIENT_ID}&redirect_uri=${process.env.REACT_APP_PUBLIC_GITHUB_CALLBACK}&state=${ghID}`;
 
-    // eslint-disable-next-line max-len
-    const githubUrl = `https://github.com/login/oauth/authorize?client_id=${process.env.REACT_APP_PUBLIC_GITHUB_CLIENT_ID}&redirect_uri=${process.env.REACT_APP_PUBLIC_GITHUB_CALLBACK}&state=${ghID}`;
+      const result = await openOauthWindow(
+        authUrl,
+        "github_oauth_channel",
+        "github",
+        ghID
+      );
 
-    if (authWindow) {
-      authWindow.location = githubUrl;
-    }
-  }
-
-  // Listener to watch for oauth redirect response on other windows (on the same host)
-  function listenForRedirect(e: {
-    target: string;
-    data: { code: string; state: string };
-  }) {
-    // when receiving github oauth response from a spawned child run fetchVerifiableCredential
-    if (e.target === "github") {
-      // pull data from message
-      const { code } = e.data;
-
-      if (GHID !== e.data.state) {
-        return;
-      }
-
-      // fetch and store credential
-      fetchVerifiableCredential(
-        process.env.REACT_APP_PASSPORT_IAM_URL || "",
-        {
-          type: CredentialProvider.Github,
-          version: "0.0.0",
-          address: props.account || "",
-          org,
-          requestedClient: ClientType.GrantHub,
-          proofs: {
-            code, // provided by github as query params in the redirect
+      const verified: { credential: VerifiableCredential } =
+        await fetchVerifiableCredential(
+          process.env.REACT_APP_PASSPORT_IAM_URL || "",
+          {
+            type: CredentialProvider.Github,
+            version: "0.0.0",
+            address: props.account || "",
+            org,
+            requestedClient: ClientType.GrantHub,
+            proofs: {
+              code: result.code, // provided by github as query params in the redirect
+            },
           },
-        },
-        signer as { signMessage: (message: string) => Promise<string> }
-      )
-        .then(async (verified: { credential: any }): Promise<void> => {
-          dispatch(
-            credentialsSaved({
-              github: verified.credential!,
-            })
-          );
-          verificationError();
+          signer as { signMessage: (message: string) => Promise<string> }
+        );
+
+      dispatch(
+        credentialsSaved({
+          github: verified.credential!,
         })
-        .catch((error) => {
-          let errorMessage;
-          // adding a console log here to help debug
-          console.log("Error on Github verification", error);
-          // todo: this is a fix for only this specific error, we should handle this better
-          if (props.formMetaData.projectGithub) {
-            // eslint-disable-next-line max-len
-            errorMessage = `There was an issue with verifying your GitHub account, please try again.`;
-          } else {
-            errorMessage =
-              // eslint-disable-next-line max-len
-              "There was an issue with verifying your GitHub account, please try again.";
-          }
-          verificationError(errorMessage);
-          datadogRum.addError(error, { provider: CredentialProvider.Github });
-          datadogLogs.logger.error("GitHub verification failed", error);
-        });
+      );
+
+      verificationError();
+    } catch (error) {
+      if (error instanceof VerificationError) {
+        verificationError(error.message);
+      } else {
+        console.error(error);
+        let errorMessage;
+        if (props.formMetaData.projectGithub) {
+          // eslint-disable-next-line max-len
+          errorMessage = `There was an issue with verifying your GitHub account, please make sure your Github account is a public member of the Github Organization and try again.`;
+        } else {
+          // eslint-disable-next-line max-len
+          errorMessage = `There was an issue with verifying your GitHub account, please try again.`;
+        }
+        verificationError(errorMessage);
+        datadogLogs.logger.error("Github verification failed");
+        datadogRum.addError(error, { provider: CredentialProvider.Github });
+      }
     }
   }
-
-  // attach and destroy a BroadcastChannel to handle the message
-  useEffect(() => {
-    // open the channel
-    const channel = new BroadcastChannel("github_oauth_channel");
-    // event handler will listen for messages from the child (debounced to avoid multiple submissions)
-    channel.onmessage = debounce(
-      (event: { target: string; data: { code: string; state: string } }) => {
-        listenForRedirect(event);
-      }
-    );
-
-    return () => {
-      channel.close();
-    };
-  });
 
   if (validGithubCredential) {
     return <VerifiedBadge />;
   }
+
   return (
     <div hidden={!canVerify} className={canVerify ? "flex flex-row mt-4" : ""}>
       <Button
         disabled={org?.length === 0}
         styles={["ml-8 w-auto mt-12"]}
         variant={ButtonVariants.secondary}
-        onClick={() => handleFetchGithubOAuth()}
+        onClick={() => handleVerify()}
       >
         Verify
       </Button>

--- a/packages/builder/src/components/providers/Twitter.tsx
+++ b/packages/builder/src/components/providers/Twitter.tsx
@@ -118,7 +118,7 @@ export default function Twitter({
   return (
     <div hidden={!canVerify} className={canVerify ? "flex flex-row mt-4" : ""}>
       <Button
-        disabled={handle?.length === 0 && isLoading}
+        disabled={handle?.length === 0}
         styles={["ml-8 w-auto mt-12"]}
         variant={ButtonVariants.secondary}
         onClick={() => handleVerify()}

--- a/packages/builder/src/components/providers/Twitter.tsx
+++ b/packages/builder/src/components/providers/Twitter.tsx
@@ -40,7 +40,7 @@ export default function Twitter({
     };
   }, shallowEqual);
 
-  const { isValid: validCredential, isLoading } = useValidateCredential(
+  const { isValid: validCredential } = useValidateCredential(
     props.verifiableCredential,
     CredentialProvider.Twitter,
     props.formMetaData.projectTwitter

--- a/packages/builder/src/components/providers/Twitter.tsx
+++ b/packages/builder/src/components/providers/Twitter.tsx
@@ -1,4 +1,5 @@
 import { Tooltip } from "@chakra-ui/react";
+import { useEffect } from "react";
 import { datadogLogs } from "@datadog/browser-logs";
 import { datadogRum } from "@datadog/browser-rum";
 import { QuestionMarkCircleIcon } from "@heroicons/react/24/solid";
@@ -39,13 +40,22 @@ export default function Twitter({
     };
   }, shallowEqual);
 
-  const { isValid: validTwitterCredential } = useValidateCredential(
+  const {
+    isValid: validCredential,
+    error: validationError,
+    isLoading,
+  } = useValidateCredential(
     props.verifiableCredential,
     CredentialProvider.Twitter,
     props.formMetaData.projectTwitter
   );
 
   const { signer } = global;
+
+  // pass the validation error to the parent component
+  useEffect(() => {
+    verificationError(validationError);
+  }, [validationError]);
 
   // Fetch Twitter OAuth2 url from the IAM procedure
   async function handleVerify(): Promise<void> {
@@ -104,14 +114,14 @@ export default function Twitter({
     }
   }
 
-  if (validTwitterCredential) {
+  if (validCredential) {
     return <VerifiedBadge />;
   }
 
   return (
     <div hidden={!canVerify} className={canVerify ? "flex flex-row mt-4" : ""}>
       <Button
-        disabled={handle?.length === 0}
+        disabled={handle?.length === 0 && isLoading}
         styles={["ml-8 w-auto mt-12"]}
         variant={ButtonVariants.secondary}
         onClick={() => handleVerify()}

--- a/packages/builder/src/components/providers/Twitter.tsx
+++ b/packages/builder/src/components/providers/Twitter.tsx
@@ -1,17 +1,16 @@
 import { Tooltip } from "@chakra-ui/react";
 import { datadogLogs } from "@datadog/browser-logs";
 import { datadogRum } from "@datadog/browser-rum";
-import { VerifiableCredential } from "@gitcoinco/passport-sdk-types";
 import { QuestionMarkCircleIcon } from "@heroicons/react/24/solid";
-import { useEffect } from "react";
 import { shallowEqual, useDispatch, useSelector } from "react-redux";
-import { BroadcastChannel } from "broadcast-channel";
-import { debounce } from "ts-debounce";
 import { global } from "../../global";
 import { RootState } from "../../reducers";
 import { CredentialProvider } from "../../types";
 import Button, { ButtonVariants } from "../base/Button";
-import { fetchVerifiableCredential } from "./identity/credentials";
+import {
+  createVerifiableCredential,
+  VerificationError,
+} from "./identity/credentials";
 import useValidateCredential from "../../hooks/useValidateCredential";
 import { credentialsSaved } from "../../actions/projectForm";
 import VerifiedBadge from "../badges/VerifiedBadge";
@@ -48,126 +47,48 @@ export default function Twitter({
 
   // Fetch Twitter OAuth2 url from the IAM procedure
   async function handleFetchTwitterOAuth(): Promise<void> {
-    const width = 600;
-    const height = 800;
-    // eslint-disable-next-line no-restricted-globals
-    const left = screen.width / 2 - width / 2;
-    // eslint-disable-next-line no-restricted-globals
-    const top = screen.height / 2 - height / 2;
-
-    const authWindow = window.open(
-      "",
-      "_blank",
-      // eslint-disable-next-line max-len
-      `toolbar=no, location=no, directories=no, status=no, menubar=no, resizable=no, copyhistory=no, width=${width}, height=${height}, top=${top}, left=${left}`
-    );
-
     // Fetch data from external API
     try {
-      const res = await fetch(
-        `${process.env.REACT_APP_PASSPORT_PROCEDURE_URL?.replace(
-          /\/*?$/,
-          ""
-        )}/twitter/generateAuthUrl`,
-        {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-          },
-          body: JSON.stringify({
-            callback: process.env.REACT_APP_PUBLIC_PASSPORT_TWITTER_CALLBACK,
-          }),
-        }
+      const credential = await createVerifiableCredential(
+        `${process.env.REACT_APP_PASSPORT_PROCEDURE_URL}/twitter/generateAuthUrl`,
+        process.env.REACT_APP_PUBLIC_PASSPORT_TWITTER_CALLBACK!,
+        "twitter_oauth_channel",
+        CredentialProvider.Twitter,
+        props.account ?? "",
+        signer
       );
-      const data = await res.json();
 
-      if (authWindow) {
-        authWindow.location = data.authUrl;
+      const { provider } = credential.credentialSubject;
+
+      if (
+        provider &&
+        parseHandle(provider).toLocaleLowerCase() === handle.toLocaleLowerCase()
+      ) {
+        dispatch(
+          credentialsSaved({
+            twitter: credential!,
+          })
+        );
+        verificationError();
+      } else {
+        throw new VerificationError(
+          `${handle} does not match ${parseHandle(
+            provider ?? ""
+          )}, the account you authenticated with.`
+        );
       }
     } catch (error) {
-      verificationError(
-        "Couldn't connect to Twitter. Please try verifying again"
-      );
-      datadogLogs.logger.error("Twitter verification failed");
-      datadogRum.addError(error, { provider: CredentialProvider.Twitter });
-    }
-  }
-
-  // Listener to watch for oauth redirect response on other windows (on the same host)
-  function listenForRedirect(e: {
-    target: string;
-    data: { code: string; state: string };
-  }) {
-    // when receiving twitter oauth response from a spawned child run fetchVerifiableCredential
-    if (e.target === "twitter") {
-      // pull data from message
-      const queryCode = e.data.code;
-      const queryState = e.data.state;
-
-      fetchVerifiableCredential(
-        process.env.REACT_APP_PASSPORT_IAM_URL || "",
-        {
-          type: CredentialProvider.Twitter,
-          version: "0.0.0",
-          address: props.account || "",
-          proofs: {
-            code: queryCode, // provided by twitter as query params in the redirect
-            sessionKey: queryState,
-          },
-        },
-        signer as { signMessage: (message: string) => Promise<string> }
-      )
-        .then(
-          async (verified: {
-            credential: VerifiableCredential;
-          }): Promise<void> => {
-            const { provider } = verified.credential.credentialSubject;
-            if (
-              provider &&
-              parseHandle(provider).toLocaleLowerCase() ===
-                handle.toLocaleLowerCase()
-            ) {
-              dispatch(
-                credentialsSaved({
-                  twitter: verified.credential!,
-                })
-              );
-              verificationError();
-            } else {
-              verificationError(
-                `${handle} does not match ${parseHandle(
-                  provider ?? ""
-                )}, the account you authenticated with.`
-              );
-            }
-          }
-        )
-        .catch((error) => {
-          verificationError(
-            "Couldn't connect to Twitter. Please try verifying again"
-          );
-          datadogLogs.logger.error("Twitter verification failed", error);
-          datadogRum.addError(error, { provider: CredentialProvider.Twitter });
-        })
-        .finally(() => {});
-    }
-  }
-
-  // attach and destroy a BroadcastChannel to handle the message
-  useEffect(() => {
-    // open the channel
-    const channel = new BroadcastChannel("twitter_oauth_channel");
-    // event handler will listen for messages from the child (debounced to avoid multiple submissions)
-    channel.onmessage = debounce(
-      (event: { target: string; data: { code: string; state: string } }) => {
-        listenForRedirect(event);
+      if (error instanceof VerificationError) {
+        verificationError(error.message);
+      } else {
+        verificationError(
+          "Couldn't connect to Twitter. Please try verifying again"
+        );
+        datadogLogs.logger.error("Twitter verification failed");
+        datadogRum.addError(error, { provider: CredentialProvider.Twitter });
       }
-    );
-
-    return () => {
-      channel.close();
-    };
-  });
+    }
+  }
 
   if (validTwitterCredential) {
     return <VerifiedBadge />;

--- a/packages/builder/src/components/providers/identity/__tests__/credentials.test.ts
+++ b/packages/builder/src/components/providers/identity/__tests__/credentials.test.ts
@@ -100,14 +100,6 @@ describe("Fetch Credentials", () => {
     expect(record).toEqual(MOCK_VERIFY_RESPONSE_BODY.record);
   });
 
-  it("will fail if not provided a signer to sign the message", async () => {
-    await expect(
-      fetchVerifiableCredential(IAM_URL, payload, undefined)
-    ).rejects.toThrow("Unable to sign message without a signer");
-
-    expect(axios.post).not.toBeCalled();
-  });
-
   it("will not attempt to sign if not provided a challenge in the challenge credential", async () => {
     jest.spyOn(axios, "post").mockResolvedValueOnce({
       data: {

--- a/packages/builder/src/components/providers/identity/credentials.ts
+++ b/packages/builder/src/components/providers/identity/credentials.ts
@@ -60,13 +60,8 @@ export class VerificationError extends Error {
 export const fetchVerifiableCredential = async (
   iamUrl: string,
   payload: GHOrgRequestPayload,
-  signer: { signMessage: (message: string) => Promise<string> } | undefined
+  signer: { signMessage: (message: string) => Promise<string> }
 ): Promise<VerifiableCredentialRecord> => {
-  // must provide signature for message
-  if (!signer) {
-    throw new Error("Unable to sign message without a signer");
-  }
-
   // first pull a challenge that can be signed by the user
   const { challenge } = await fetchChallengeCredential(iamUrl, payload);
 

--- a/packages/builder/src/components/providers/identity/credentials.ts
+++ b/packages/builder/src/components/providers/identity/credentials.ts
@@ -1,6 +1,5 @@
 // --- Node/Browser http req library
 import axios from "axios";
-import { datadogLogs } from "@datadog/browser-logs";
 import {
   RequestPayload,
   IssuedChallenge,
@@ -20,21 +19,16 @@ export const fetchChallengeCredential = async (
   payload: RequestPayload
 ): Promise<IssuedChallenge> => {
   // fetch challenge as a credential from API that fits the version, address and type (this credential has a short ttl)
+  const response = await axios.post(
+    `${iamUrl.replace(/\/*?$/, "")}/v${payload.version}/challenge`,
+    {
+      payload: {
+        address: payload.address,
+        type: payload.type,
+      },
+    }
+  );
 
-  let response;
-  try {
-    response = await axios.post(
-      `${iamUrl.replace(/\/*?$/, "")}/v${payload.version}/challenge`,
-      {
-        payload: {
-          address: payload.address,
-          type: payload.type,
-        },
-      }
-    );
-  } catch (error) {
-    datadogLogs.logger.error(`Error fetching challenge credential ${error}`);
-  }
   return {
     challenge: response?.data.credential,
   } as IssuedChallenge;

--- a/packages/builder/src/hooks/useValidateCredential.tsx
+++ b/packages/builder/src/hooks/useValidateCredential.tsx
@@ -25,6 +25,7 @@ export default function useValidateCredential(
           credential.credentialSubject.provider?.split("#")[1].toLowerCase() ===
           handle.toLowerCase();
         const validCredential = await verifier.verifyCredential(credential);
+
         const validIssuer = IAM_SERVER === credential.issuer;
         // TODO: add owner check
         // address of vc.credentialSubject.id should be a project owner

--- a/packages/builder/src/index.tsx
+++ b/packages/builder/src/index.tsx
@@ -43,6 +43,44 @@ initTagmanager();
 
 datadogRum.addAction("Init");
 
+const queryString = new URLSearchParams(window?.location?.search);
+
+// Twitter oauth will attach code & state in oauth procedure
+const queryError = queryString.get("error");
+const queryCode = queryString.get("code");
+const queryState = queryString.get("state");
+
+// if Twitter oauth then submit message to other windows and close self
+if ((queryError || queryCode) && queryState && /^twitter-.*/.test(queryState)) {
+  // shared message channel between windows (on the same domain)
+  const channel = new BroadcastChannel("twitter_oauth_channel");
+  // only continue with the process if a code is returned
+  if (queryCode) {
+    channel.postMessage({
+      target: "twitter",
+      data: { error: queryError, code: queryCode, state: queryState },
+    });
+  }
+  // always close the redirected window
+  window.close();
+}
+
+// if Github oauth then submit message to other windows and close self
+if ((queryError || queryCode) && queryState && /^github-.*/.test(queryState)) {
+  // shared message channel between windows (on the same domain)
+  const channel = new BroadcastChannel("github_oauth_channel");
+  // only continue with the process if a code is returned
+  if (queryCode) {
+    channel.postMessage({
+      target: "github",
+      data: { error: queryError, code: queryCode, state: queryState },
+    });
+  }
+
+  // always close the redirected window
+  window.close();
+}
+
 const pathname = process.env.REACT_APP_PATHNAME;
 if (pathname && pathname !== window.location.pathname) {
   window.location.pathname = pathname;


### PR DESCRIPTION
<!-- 
Thank you for your pull request! Please review the requirements below 
and ensure your pull request has fulfilled all requirements outlined in the target package.
-->

##### Description

This PR simplifies and adds better error handling amongst other refactorings.

- The BroadcastChannel callback happens inside React, this is not ideal because React could re-render the component or even not render at all, there could be a redirect etc. Since this is not related to the UI at all it now happens in the index script before anything else, this will ensure things are being called.
- Separate unexpected errors from Verification errors and surface them to the user instead of silencing, also callback with errors from OAuth which at the moment they're silenced as well.
- Unify all the logic to create credentials from OAuth instead of having relying on `useEffect`, this will ensure errors happening with this procedure will always be caught instead of just doing nothing
- Give feedback to the user if the pop up doesn't open, if it's blocked for example
- Handle and surface errors from Passport when verifying the credentials

WIP: at the moment this is only for twitter

##### Refers/Fixes

<!-- If this PR is related to a GitHub issue, please add a link here. -->

##### Testing

<!-- All PRs should be accompanied by tests! If you haven't added tests, please explain here. -->
