### PR TITLE
Add debug mode

### DIFF
--- a/packages/round-manager/.env.sample
+++ b/packages/round-manager/.env.sample
@@ -36,8 +36,9 @@ REACT_APP_TAG_MANAGER=XXXXX
 #Grant API Endpoint
 REACT_APP_GRANTS_API_ENDPOINT=#########
 
-# Ignore frontend-only ownership checks for rounds
-REACT_APP_IGNORE_FRONTEND_CHECKS=true
+# Allow using debug mode in the URL query
+REACT_APP_ALLOW_URL_DEBUG_MODE=
+REACT_APP_DEBUG_MODE=
 
 REACT_APP_INTERCOM_APP_ID=
 

--- a/packages/round-manager/src/features/program/ViewProgramPage.tsx
+++ b/packages/round-manager/src/features/program/ViewProgramPage.tsx
@@ -22,6 +22,7 @@ import { useProgramById } from "../../context/program/ReadProgramContext";
 import { Spinner } from "../common/Spinner";
 import { useRounds } from "../../context/round/RoundContext";
 import { ProgressStatus } from "../api/types";
+import { useDebugMode } from "../../hooks";
 
 export default function ViewProgram() {
   datadogLogs.logger.info("====> Route: /program/:id");
@@ -40,10 +41,16 @@ export default function ViewProgram() {
 
   const [programExists, setProgramExists] = useState(true);
   const [hasAccess, setHasAccess] = useState(true);
+  const debugModeEnabled = useDebugMode();
 
   useEffect(() => {
     if (isProgramFetched) {
       setProgramExists(!!programToRender);
+
+      if (debugModeEnabled) {
+        setHasAccess(true);
+        return;
+      }
 
       if (programToRender) {
         programToRender.operatorWallets.includes(address?.toLowerCase())
@@ -53,7 +60,7 @@ export default function ViewProgram() {
         setHasAccess(true);
       }
     }
-  }, [isProgramFetched, programToRender, address]);
+  }, [isProgramFetched, programToRender, address, debugModeEnabled]);
 
   const roundItems = rounds
     ? rounds.map((round, index) => (

--- a/packages/round-manager/src/features/round/ViewApplicationPage.tsx
+++ b/packages/round-manager/src/features/round/ViewApplicationPage.tsx
@@ -48,6 +48,7 @@ import {
   VerifiedCredentialState,
 } from "common";
 import { renderToHTML } from "common";
+import { useDebugMode } from "../../hooks";
 
 type ApplicationStatus = "APPROVED" | "REJECTED";
 
@@ -83,7 +84,7 @@ export default function ViewApplicationPage() {
   const { applications, isLoading } = useApplicationByRoundId(roundId!);
   const filteredApplication = applications?.filter((a) => a.id == id) || [];
   const application = filteredApplication[0];
-  
+
   const {
     bulkUpdateGrantApplications,
     contractUpdatingStatus,
@@ -222,19 +223,14 @@ export default function ViewApplicationPage() {
 
   const [applicationExists, setApplicationExists] = useState(true);
   const [hasAccess, setHasAccess] = useState(true);
+  const debugModeEnabled = useDebugMode();
 
   useEffect(() => {
     if (!isLoading) {
       setApplicationExists(!!application);
 
-      /* During development, give frontend access to all rounds */
-      if (process.env.REACT_APP_IGNORE_FRONTEND_CHECKS) {
-        setHasAccess(true);
-        return;
-      }
-
-      /* During development, give frontend access to all rounds */
-      if (process.env.REACT_APP_IGNORE_FRONTEND_CHECKS) {
+      /* In debug mode, give frontend access to all rounds */
+      if (debugModeEnabled) {
         setHasAccess(true);
         return;
       }
@@ -243,7 +239,7 @@ export default function ViewApplicationPage() {
         setHasAccess(!!round.operatorWallets?.includes(address?.toLowerCase()));
       }
     }
-  }, [address, application, isLoading, round]);
+  }, [address, application, isLoading, round, debugModeEnabled]);
 
   const [answerBlocks, setAnswerBlocks] = useState<AnswerBlock[]>();
   useEffect(() => {
@@ -304,7 +300,8 @@ export default function ViewApplicationPage() {
   }, [application, hasAccess, isLoading]);
 
   // Handle case where project github is not set but user github is set. if both are not available, set to null
-  const registeredGithub = application?.project?.projectGithub ?? application?.project?.userGithub;
+  const registeredGithub =
+    application?.project?.projectGithub ?? application?.project?.userGithub;
 
   return isLoading ? (
     <Spinner text="We're fetching the round application." />
@@ -427,8 +424,10 @@ export default function ViewApplicationPage() {
               <div className="sm:flex sm:justify-between my-6">
                 <div className="sm:basis-3/4 sm:mr-3">
                   <div className="grid sm:grid-cols-3 gap-2 md:gap-10">
-
-                    <span className="text-grey-500 flex flex-row justify-start items-center" data-testid="twitter-info">
+                    <span
+                      className="text-grey-500 flex flex-row justify-start items-center"
+                      data-testid="twitter-info"
+                    >
                       <TwitterIcon className="h-4 w-4 mr-2" />
                       <a
                         href={`https://twitter.com/${application?.project?.projectTwitter}`}
@@ -441,7 +440,10 @@ export default function ViewApplicationPage() {
                       {getVerifiableCredentialVerificationResultView("twitter")}
                     </span>
 
-                    <span className="text-grey-500 flex flex-row justify-start items-center" data-testid="github-info">
+                    <span
+                      className="text-grey-500 flex flex-row justify-start items-center"
+                      data-testid="github-info"
+                    >
                       <GithubIcon className="h-4 w-4 mr-2" />
                       <a
                         href={`https://github.com/${registeredGithub}`}

--- a/packages/round-manager/src/features/round/ViewRoundPage.tsx
+++ b/packages/round-manager/src/features/round/ViewRoundPage.tsx
@@ -43,6 +43,7 @@ import ViewFundGrantees from "./ViewFundGrantees";
 import ViewRoundSettings from "./ViewRoundSettings";
 import ViewRoundStats from "./ViewRoundStats";
 import ViewRoundResults from "./ViewRoundResults/ViewRoundResults";
+import { useDebugMode } from "../../hooks";
 
 export default function ViewRoundPage() {
   datadogLogs.logger.info("====> Route: /round/:id");
@@ -59,14 +60,15 @@ export default function ViewRoundPage() {
 
   const [roundExists, setRoundExists] = useState(true);
   const [hasAccess, setHasAccess] = useState(true);
+  const debugModeEnabled = useDebugMode();
 
   useEffect(() => {
     if (isRoundsFetched) {
       setRoundExists(!!round);
 
       if (round) {
-        /* During development, give frontend access to all rounds */
-        if (process.env.REACT_APP_IGNORE_FRONTEND_CHECKS) {
+        /* In debug mode, give frontend access to all rounds */
+        if (debugModeEnabled) {
           setHasAccess(true);
           return;
         }
@@ -77,7 +79,7 @@ export default function ViewRoundPage() {
         setHasAccess(true);
       }
     }
-  }, [isRoundsFetched, round, address]);
+  }, [isRoundsFetched, round, address, debugModeEnabled]);
 
   return (
     <>

--- a/packages/round-manager/src/features/round/ViewRoundResults/ViewRoundResults.tsx
+++ b/packages/round-manager/src/features/round/ViewRoundResults/ViewRoundResults.tsx
@@ -14,7 +14,7 @@ import {
 } from "react-dropzone";
 import { RefreshIcon, ExclamationCircleIcon } from "@heroicons/react/solid";
 import { classNames } from "common";
-import { useRound, useRoundMatchingFunds } from "../../../hooks";
+import { useDebugMode, useRound, useRoundMatchingFunds } from "../../../hooks";
 import { MatchingStatsData } from "../../api/types";
 import { Match } from "allo-indexer-client";
 
@@ -37,6 +37,7 @@ export default function ViewRoundResults() {
   const { id } = useParams();
   const roundId = utils.getAddress(id?.toLowerCase() ?? "");
   const { data: matches } = useRoundMatchingFunds(roundId);
+  const debugModeEnabled = useDebugMode();
 
   const [distributionOption, setDistributionOption] = useState("keep");
 
@@ -73,7 +74,7 @@ export default function ViewRoundResults() {
   const currentTime = new Date();
   const isBeforeRoundEndDate = round && currentTime < round.roundEndTime;
 
-  if (isBeforeRoundEndDate) {
+  if (isBeforeRoundEndDate && !debugModeEnabled) {
     return <NoInformationContent />;
   }
 

--- a/packages/round-manager/src/hooks.ts
+++ b/packages/round-manager/src/hooks.ts
@@ -2,6 +2,17 @@ import useSWR from "swr";
 import { Client } from "allo-indexer-client";
 import { useWallet } from "./features/common/Auth";
 import { useMemo } from "react";
+import { useSearchParams } from "react-router-dom";
+
+export function useDebugMode(): boolean {
+  const [searchParams] = useSearchParams();
+
+  return (
+    (process.env.REACT_APP_ALLOW_URL_DEBUG_MODE === "true" &&
+      searchParams.get("debug") === "true") ||
+    process.env.REACT_APP_DEBUG_MODE === "true"
+  );
+}
 
 export function useAlloIndexerClient(): Client {
   const { chain } = useWallet();


### PR DESCRIPTION
<!-- 
Thank you for your pull request! Please review the requirements below 
and ensure your pull request has fulfilled all requirements outlined in the target package.
-->

##### Description

This PR adds a debug mode to the Manager app, which allows you to see rounds you normally don't have access to (for example to test a production round), access pages that might be disabled (for example the round results page) for testing and debugging, this is how it works:

`REACT_APP_ALLOW_URL_DEBUG_MODE=true`

When this environment variable is `true` it allows enabling debug mode via a URL query param, for example:

http://localhost:3000/#/round/0x6e8dC2e623204D61b0E59E668702654aE336c9f7?debug=true

Will enable debug mode for that page.

This option is useful for testing in staging or even production, where we only want to enable debug mode when convenient but not all the time.

`REACT_APP_DEBUG_MODE=true`

This environment variable enables debug mode all the time, this can be useful in development where we might want to navigate without restrictions to develop.


<!-- Describe your changes here. -->

##### Refers/Fixes

<!-- If this PR is related to a GitHub issue, please add a link here. -->

##### Testing

<!-- All PRs should be accompanied by tests! If you haven't added tests, please explain here. -->
