### PR TITLE
Fix Project stats in Builder and Explorer

### DIFF
--- a/packages/builder/package.json
+++ b/packages/builder/package.json
@@ -35,7 +35,7 @@
     "@types/react-redux": "^7.1.24",
     "@types/testing-library__jest-dom": "^5.14.5",
     "@wagmi/core": "0.5.4",
-    "allo-indexer-client": "github:gitcoinco/allo-indexer-client#35fba8ef3cdca7ac482dcab42e4fdb666cca0fc8",
+    "allo-indexer-client": "github:gitcoinco/allo-indexer-client#0487c02c9bb89307b12ffe75f5bfb578278994a1",
     "assert": "^2.0.0",
     "autoprefixer": "^10.4.7",
     "axios": "^0.27.2",

--- a/packages/builder/src/actions/projects.ts
+++ b/packages/builder/src/actions/projects.ts
@@ -540,14 +540,14 @@ export const loadProjectStats =
         round.chainId
       );
 
-      const project = await client
-        .getRoundApplications(utils.getAddress(round.roundId.toLowerCase()))
-        .then(
-          (apps: GrantApplication[]) =>
-            apps.filter(
-              (app: GrantApplication) => app.id === uniqueProjectID
-            )[0]
-        );
+      const applications = await client.getRoundApplications(
+        utils.getAddress(round.roundId.toLowerCase())
+      );
+
+      const project = applications.find(
+        (app) => app.projectId === uniqueProjectID && app.status === "APPROVED"
+      );
+
       if (project) {
         await updateStats(
           {

--- a/packages/builder/src/actions/projects.ts
+++ b/packages/builder/src/actions/projects.ts
@@ -2,10 +2,7 @@ import { datadogRum } from "@datadog/browser-rum";
 import { ethers, utils } from "ethers";
 import { Dispatch } from "redux";
 import { convertStatusToText } from "common";
-import {
-  Client as AlloClient,
-  Application as GrantApplication,
-} from "allo-indexer-client";
+import { Client as AlloClient } from "allo-indexer-client";
 import { addressesByChainID } from "../contracts/deployments";
 import { global } from "../global";
 import { RootState } from "../reducers";

--- a/packages/grant-explorer/package.json
+++ b/packages/grant-explorer/package.json
@@ -65,7 +65,7 @@
     "@testing-library/jest-dom": "^5.16.4",
     "@testing-library/react": "^13.0.1",
     "@testing-library/user-event": "^14.1.1",
-    "allo-indexer-client": "github:gitcoinco/allo-indexer-client#35fba8ef3cdca7ac482dcab42e4fdb666cca0fc8",
+    "allo-indexer-client": "github:gitcoinco/allo-indexer-client#0487c02c9bb89307b12ffe75f5bfb578278994a1",
     "babel-loader": "^8.3.0",
     "buffer": "^6.0.3",
     "common": "workspace:*",

--- a/packages/grant-explorer/src/features/round/ViewProjectDetails.tsx
+++ b/packages/grant-explorer/src/features/round/ViewProjectDetails.tsx
@@ -7,7 +7,7 @@ import {
   GlobeAltIcon,
   ShieldCheckIcon,
 } from "@heroicons/react/24/solid";
-import { Application, Client } from "allo-indexer-client";
+import { Client } from "allo-indexer-client";
 import { formatDateWithOrdinal, renderToHTML } from "common";
 import { Button } from "common/src/styles";
 import { formatDistanceToNowStrict } from "date-fns";
@@ -462,7 +462,7 @@ function Sidebar(props: {
 }
 
 // NOTE: Consider moving this
-export function useRoundApplication(
+export function useRoundApprovedApplication(
   chainId: number,
   roundId: string,
   projectId: string
@@ -494,7 +494,7 @@ export function ProjectStats() {
     (project) => project.grantApplicationId === applicationId
   );
 
-  const { data: application } = useRoundApplication(
+  const { data: application } = useRoundApprovedApplication(
     Number(chainId),
     roundId as string,
     projectToRender?.projectRegistryId as string
@@ -507,11 +507,11 @@ export function ProjectStats() {
   return (
     <div className={"rounded bg-gray-50 mb-4 p-4 gap-4 flex flex-col"}>
       <div>
-        <h3>${application ? application[0].amountUSD.toFixed(2) : "-"}</h3>
+        <h3>${application?.amountUSD.toFixed(2) ?? "-"}</h3>
         <p>funding received in current round</p>
       </div>
       <div>
-        <h3>{application ? application[0].uniqueContributors : "-"}</h3>
+        <h3>{application?.uniqueContributors ?? "-"}</h3>
         <p>contributors</p>
       </div>
       <div>

--- a/packages/grant-explorer/src/features/round/ViewProjectDetails.tsx
+++ b/packages/grant-explorer/src/features/round/ViewProjectDetails.tsx
@@ -462,7 +462,7 @@ function Sidebar(props: {
 }
 
 // NOTE: Consider moving this
-export function useRoundProject(
+export function useRoundApplication(
   chainId: number,
   roundId: string,
   projectId: string
@@ -474,13 +474,15 @@ export function useRoundProject(
     chainId
   );
 
-  return useSWR([roundId, "/projects"], ([roundId]) =>
-    client
-      .getRoundApplications(utils.getAddress(roundId.toLowerCase()))
-      .then((apps: Application[]) =>
-        apps.filter((app: Application) => app.id === projectId)
-      )
-  );
+  return useSWR([roundId, "/projects"], async ([roundId]) => {
+    const applications = await client.getRoundApplications(
+      utils.getAddress(roundId.toLowerCase())
+    );
+
+    return applications.find(
+      (app) => app.projectId === projectId && app.status === "APPROVED"
+    );
+  });
 }
 
 export function ProjectStats() {
@@ -492,7 +494,7 @@ export function ProjectStats() {
     (project) => project.grantApplicationId === applicationId
   );
 
-  const { data: project } = useRoundProject(
+  const { data: application } = useRoundApplication(
     Number(chainId),
     roundId as string,
     projectToRender?.projectRegistryId as string
@@ -505,11 +507,11 @@ export function ProjectStats() {
   return (
     <div className={"rounded bg-gray-50 mb-4 p-4 gap-4 flex flex-col"}>
       <div>
-        <h3>${project ? project[0].amountUSD.toFixed(2) : "-"}</h3>
+        <h3>${application ? application[0].amountUSD.toFixed(2) : "-"}</h3>
         <p>funding received in current round</p>
       </div>
       <div>
-        <h3>{project ? project[0].uniqueContributors : "-"}</h3>
+        <h3>{application ? application[0].uniqueContributors : "-"}</h3>
         <p>contributors</p>
       </div>
       <div>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -120,7 +120,7 @@ importers:
       '@typescript-eslint/eslint-plugin': ^5.23.0
       '@typescript-eslint/parser': ^5.23.0
       '@wagmi/core': 0.5.4
-      allo-indexer-client: github:gitcoinco/allo-indexer-client#35fba8ef3cdca7ac482dcab42e4fdb666cca0fc8
+      allo-indexer-client: github:gitcoinco/allo-indexer-client#0487c02c9bb89307b12ffe75f5bfb578278994a1
       assert: ^2.0.0
       autoprefixer: ^10.4.7
       axios: ^0.27.2
@@ -210,7 +210,7 @@ importers:
       '@types/react-redux': 7.1.25
       '@types/testing-library__jest-dom': 5.14.5
       '@wagmi/core': 0.5.4_ethers@5.6.5+react@18.2.0
-      allo-indexer-client: github.com/gitcoinco/allo-indexer-client/35fba8ef3cdca7ac482dcab42e4fdb666cca0fc8
+      allo-indexer-client: github.com/gitcoinco/allo-indexer-client/0487c02c9bb89307b12ffe75f5bfb578278994a1
       assert: 2.0.0
       autoprefixer: 10.4.13_postcss@8.4.21
       axios: 0.27.2
@@ -366,7 +366,7 @@ importers:
       '@types/react-dom': ^18.0.2
       '@types/react-gtm-module': ^2.0.1
       '@types/testing-library__jest-dom': ^5.14.5
-      allo-indexer-client: github:gitcoinco/allo-indexer-client#35fba8ef3cdca7ac482dcab42e4fdb666cca0fc8
+      allo-indexer-client: github:gitcoinco/allo-indexer-client#0487c02c9bb89307b12ffe75f5bfb578278994a1
       autoprefixer: ^10.4.7
       babel-loader: ^8.3.0
       buffer: ^6.0.3
@@ -439,7 +439,7 @@ importers:
       '@testing-library/jest-dom': 5.16.5
       '@testing-library/react': 13.4.0_biqbaboplfbrettd7655fr4n2y
       '@testing-library/user-event': 14.4.3_yxlyej73nftwmh2fiao7paxmlm
-      allo-indexer-client: github.com/gitcoinco/allo-indexer-client/35fba8ef3cdca7ac482dcab42e4fdb666cca0fc8
+      allo-indexer-client: github.com/gitcoinco/allo-indexer-client/0487c02c9bb89307b12ffe75f5bfb578278994a1
       babel-loader: 8.3.0_la66t7xldg4uecmyawueag5wkm
       buffer: 6.0.3
       common: link:../common
@@ -6557,7 +6557,7 @@ packages:
     resolution: {integrity: sha512-ALYone6pm6QmwZoAgeyNksccT9Q4AWZQ6PvfwR37GT6r6FWUPguq6sUmNGSMV2Wr761oQoBxwGGa6DR5o1DC9g==}
     dependencies:
       '@types/connect': 3.4.35
-      '@types/node': 17.0.45
+      '@types/node': 18.15.5
 
   /@types/bonjour/3.5.10:
     resolution: {integrity: sha512-p7ienRMiS41Nu2/igbJxxLDWrSZ0WxM8UQgCeO9KhoVF7cOVFkrKsiDr1EsJIla8vV3oEEjGcz11jc5yimhzZw==}
@@ -8556,7 +8556,7 @@ packages:
   /axios/0.21.4_debug@4.3.4:
     resolution: {integrity: sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==}
     dependencies:
-      follow-redirects: 1.15.2_debug@4.3.4
+      follow-redirects: 1.15.2
     transitivePeerDependencies:
       - debug
     dev: true
@@ -12624,18 +12624,6 @@ packages:
     peerDependenciesMeta:
       debug:
         optional: true
-
-  /follow-redirects/1.15.2_debug@4.3.4:
-    resolution: {integrity: sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==}
-    engines: {node: '>=4.0'}
-    peerDependencies:
-      debug: '*'
-    peerDependenciesMeta:
-      debug:
-        optional: true
-    dependencies:
-      debug: 4.3.4
-    dev: true
 
   /for-each/0.3.3:
     resolution: {integrity: sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==}
@@ -23950,8 +23938,8 @@ packages:
       ethereumjs-util: 6.2.1
     dev: false
 
-  github.com/gitcoinco/allo-indexer-client/35fba8ef3cdca7ac482dcab42e4fdb666cca0fc8:
-    resolution: {tarball: https://codeload.github.com/gitcoinco/allo-indexer-client/tar.gz/35fba8ef3cdca7ac482dcab42e4fdb666cca0fc8}
+  github.com/gitcoinco/allo-indexer-client/0487c02c9bb89307b12ffe75f5bfb578278994a1:
+    resolution: {tarball: https://codeload.github.com/gitcoinco/allo-indexer-client/tar.gz/0487c02c9bb89307b12ffe75f5bfb578278994a1}
     name: allo-indexer-client
     version: 0.1.0
     hasBin: true


### PR DESCRIPTION
<!-- 
Thank you for your pull request! Please review the requirements below 
and ensure your pull request has fulfilled all requirements outlined in the target package.
-->

##### Description

depends on https://github.com/gitcoinco/allo-indexer-client/pull/14

This fixes the project stats for Builder and Explorer.

To clarify things, when we get applications from the indexer you get actual applications, not projects, so you can have multiple applications for a single project. The application ID is the index for new rounds and it's the projectId for old rounds (because we don't have an index), so we need to explicitly use `.projectId` if we want to filter by project.

We need to test this for new rounds as well not just old.

<!-- Describe your changes here. -->

##### Refers/Fixes

<!-- If this PR is related to a GitHub issue, please add a link here. -->

##### Testing

<!-- All PRs should be accompanied by tests! If you haven't added tests, please explain here. -->
