### PR TITLE
feat: separate ipfs and contract upload steps during finalization

### DIFF
--- a/packages/round-manager/src/features/round/ViewRoundResults/ViewRoundResults.tsx
+++ b/packages/round-manager/src/features/round/ViewRoundResults/ViewRoundResults.tsx
@@ -1,11 +1,14 @@
-import { useCallback, useState, useRef, useMemo } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { BigNumber, utils } from "ethers";
 import { RadioGroup, Tab } from "@headlessui/react";
 import { ExclamationCircleIcon as NoInformationIcon } from "@heroicons/react/outline";
-import { DownloadIcon, UploadIcon } from "@heroicons/react/solid";
+import {
+  DownloadIcon,
+  ExclamationCircleIcon,
+  UploadIcon,
+} from "@heroicons/react/solid";
 import { useDropzone } from "react-dropzone";
-import { ExclamationCircleIcon } from "@heroicons/react/solid";
 import { classNames } from "common";
 import { Button } from "common/src/styles";
 import { useDebugMode, useRound, useRoundMatchingFunds } from "../../../hooks";
@@ -196,7 +199,7 @@ export default function ViewRoundResults() {
   const [readyForPayoutTransaction, setReadyforPayoutTransaction] =
     useState<TransactionResponse>();
 
-  const { finalizeRound, IPFSCurrentStatus, finalizeRoundToContractStatus } =
+  const { finalizeRound, finalizeRoundToContractStatus, IPFSCurrentStatus } =
     useFinalizeRound();
 
   const onFinalizeResults = async () => {
@@ -245,21 +248,32 @@ export default function ViewRoundResults() {
 
   const progressSteps: ProgressStep[] = [
     {
+      name: "uploading to IPFS",
+      description: "The matching distribution is being uploaded to IPFS.",
+      status: IPFSCurrentStatus,
+    },
+    {
       name: "saving",
       description:
         "The matching distribution is being saved onto the contract.",
-      status: IPFSCurrentStatus,
+      status: finalizeRoundToContractStatus,
     },
     {
       name: "Finalizing",
       description: `The contract is being marked as eligible for payouts.`,
-      status: finalizeRoundToContractStatus,
+      status:
+        finalizeRoundToContractStatus === ProgressStatus.IS_SUCCESS
+          ? readyForPayoutTransaction
+            ? ProgressStatus.IS_SUCCESS
+            : ProgressStatus.IN_PROGRESS
+          : ProgressStatus.NOT_STARTED,
     },
     {
       name: "finishing up",
       description: "We’re wrapping up.",
       status:
-        finalizeRoundToContractStatus === ProgressStatus.IS_SUCCESS
+        finalizeRoundToContractStatus === ProgressStatus.IS_SUCCESS &&
+        readyForPayoutTransaction !== undefined
           ? ProgressStatus.IN_PROGRESS
           : ProgressStatus.NOT_STARTED,
     },
@@ -275,10 +289,17 @@ export default function ViewRoundResults() {
 
   const roundSaturation =
     Number(
-      ((sumOfMatches * BigInt(10000)) / round.matchAmount) * BigInt(10000)
-    ) / 1000000;
+      ((sumOfMatches * BigInt(10_000)) / round.matchAmount) * BigInt(10_000)
+    ) / 1_000_000;
 
-  const disableRoundSaturationControls = roundSaturation >= 100;
+  const disableRoundSaturationControls = Math.round(roundSaturation) >= 100;
+
+  console.log(
+    "Finalize eround status",
+    finalizeRoundToContractStatus,
+    " ready for payout status ",
+    readyForPayoutTransaction
+  );
 
   return (
     <div className="flex flex-center flex-col mx-auto mt-3 mb-[212px]">


### PR DESCRIPTION
modifies the modal so that there is a new step.

Upload distribution to IPFS -> Set hash in Contract -> Set as Ready for Payout -> Final step (don't what what it's for but it's in the designs and all the other modals)

the code isn't ideal, but the whole context and handling of finalizing to contract needs to be redone anyway, so this is temporary.

fixes #1764 