### PR TITLE
Manager: add ability to set a round or edit a round to be public or private

### DIFF
--- a/packages/round-manager/src/features/api/types.ts
+++ b/packages/round-manager/src/features/api/types.ts
@@ -150,6 +150,7 @@ export interface Round {
   roundMetadata: {
     name: string;
     programContractAddress: string;
+    roundType: string;
     eligibility?: {
       description: string;
       requirements: { requirement: string }[];

--- a/packages/round-manager/src/features/round/RoundDetailForm.tsx
+++ b/packages/round-manager/src/features/round/RoundDetailForm.tsx
@@ -14,7 +14,7 @@ import {
 } from "react-hook-form";
 import * as yup from "yup";
 
-import { Listbox, Transition } from "@headlessui/react";
+import { Listbox, RadioGroup, Transition } from "@headlessui/react";
 import {
   CheckIcon,
   InformationCircleIcon,
@@ -178,7 +178,7 @@ export function RoundDetailForm(props: RoundDetailFormProps) {
             onSubmit={handleSubmit(next)}
             className="shadow-sm text-grey-500"
           >
-            <div className="pt-7 pb-10 sm:px-6 bg-white">
+            <div className="pt-7 sm:px-6 bg-white">
               <div className="grid grid-cols-6 gap-6">
                 <RoundName
                   register={register("roundMetadata.name")}
@@ -474,6 +474,23 @@ export function RoundDetailForm(props: RoundDetailFormProps) {
                     </p>
                   )}
                 </div>
+              </div>
+            </div>
+
+            {/* Round Type */}
+            <div className="p-6 bg-white">
+              <div className="grid grid-rows-1">
+                <p>
+                  Do you want to show your round on the Gitcoin Explorer
+                  homepage?
+                </p>
+              </div>
+              <div className="flex mt-4">
+                <RoundType
+                  errors={errors}
+                  register={register("roundMetadata.roundType")}
+                  control={control}
+                />
               </div>
             </div>
 
@@ -796,6 +813,90 @@ function ApplicationDatesInformation() {
       >
         <p className="text-xs">All dates are in UTC.</p>
       </ReactTooltip>
+    </>
+  );
+}
+
+function RoundType(props: {
+  register: UseFormRegisterReturn<string>;
+  errors: FieldErrors<Round>;
+  control?: Control<Round>;
+}) {
+  const { field: roundTypeField } = useController({
+    name: "roundMetadata.roundType",
+    defaultValue: "",
+    control: props.control,
+    rules: {
+      required: true,
+    },
+  });
+
+  return (
+    <>
+      {" "}
+      <div className="col-span-6 sm:col-span-3">
+        <RadioGroup {...roundTypeField} data-testid="round-type-selection">
+          <div>
+            <RadioGroup.Option value="public" className="mb-2">
+              {({ checked, active }) => (
+                <span className="flex items-center text-sm">
+                  <span
+                    className={classNames(
+                      checked
+                        ? "bg-indigo-600 border-transparent"
+                        : "bg-white border-gray-300",
+                      active ? "ring-2 ring-offset-2 ring-indigo-500" : "",
+                      "h-4 w-4 rounded-full border flex items-center justify-center"
+                    )}
+                    aria-hidden="true"
+                  >
+                    <span className="rounded-full bg-white w-1.5 h-1.5" />
+                  </span>
+                  <RadioGroup.Label
+                    as="span"
+                    className="ml-3 block text-sm text-gray-700"
+                    data-testid="round-type-public"
+                  >
+                    Yes, make my round public
+                    <p className="text-xs text-gray-400">
+                      Anyone on the Gitcoin Explorer homepage will be able to
+                      see your round
+                    </p>
+                  </RadioGroup.Label>
+                </span>
+              )}
+            </RadioGroup.Option>
+            <RadioGroup.Option value="private">
+              {({ checked, active }) => (
+                <span className="flex items-center text-sm">
+                  <span
+                    className={classNames(
+                      checked
+                        ? "bg-indigo-600 border-transparent"
+                        : "bg-white border-gray-300",
+                      active ? "ring-2 ring-offset-2 ring-indigo-500" : "",
+                      "h-4 w-4 rounded-full border flex items-center justify-center"
+                    )}
+                    aria-hidden="true"
+                  >
+                    <span className="rounded-full bg-white w-1.5 h-1.5" />
+                  </span>
+                  <RadioGroup.Label
+                    as="span"
+                    className="ml-3 block text-sm text-gray-700"
+                    data-testid="round-type-private"
+                  >
+                    No, keep my round private
+                    <p className="text-xs text-gray-400">
+                      Only people with the round link can see your round.
+                    </p>
+                  </RadioGroup.Label>
+                </span>
+              )}
+            </RadioGroup.Option>
+          </div>
+        </RadioGroup>
+      </div>
     </>
   );
 }

--- a/packages/round-manager/src/features/round/RoundDetailForm.tsx
+++ b/packages/round-manager/src/features/round/RoundDetailForm.tsx
@@ -36,6 +36,7 @@ const ValidationSchema = yup.object().shape({
       .string()
       .required("This field is required.")
       .min(8, "Round name must be at least 8 characters."),
+    roundType: yup.string().required("You must select the round type."),
     support: yup.object({
       type: yup
         .string()
@@ -487,11 +488,18 @@ export function RoundDetailForm(props: RoundDetailFormProps) {
               </div>
               <div className="flex mt-4">
                 <RoundType
-                  errors={errors}
                   register={register("roundMetadata.roundType")}
                   control={control}
                 />
               </div>
+              {errors.roundMetadata?.roundType && (
+                <p
+                  className="text-xs text-pink-500 mt-2"
+                  data-testid="round-end-date-error"
+                >
+                  {errors.roundMetadata?.roundType?.message}
+                </p>
+              )}
             </div>
 
             <div className="px-6 align-middle py-3.5 shadow-md">
@@ -819,7 +827,6 @@ function ApplicationDatesInformation() {
 
 function RoundType(props: {
   register: UseFormRegisterReturn<string>;
-  errors: FieldErrors<Round>;
   control?: Control<Round>;
 }) {
   const { field: roundTypeField } = useController({

--- a/packages/round-manager/src/features/round/__tests__/RoundDetailForm.test.tsx
+++ b/packages/round-manager/src/features/round/__tests__/RoundDetailForm.test.tsx
@@ -102,6 +102,12 @@ describe("<RoundDetailForm />", () => {
     expect(contactInfoInput).toBeInTheDocument();
   });
 
+  it("renders round type selection radio button", async () => {
+    renderWrapped(<RoundDetailForm stepper={FormStepper} />);
+    const roundTypeRadioBtn = screen.getByTestId("round-type-selection");
+    expect(roundTypeRadioBtn).toBeInTheDocument();
+  });
+
   it("requires contact information input to not be empty", async () => {
     renderWrapped(<RoundDetailForm stepper={FormStepper} />);
     const submitButton = screen.getByRole("button", {
@@ -345,6 +351,10 @@ describe("<RoundDetailForm />", () => {
     fireEvent.change(endDateInputs[1], {
       target: { value: moment(roundEndTime).format("MM/DD/YYYY h:mm A") },
     });
+
+    /* Round Type Selection */
+    const roundTypeOption = screen.getByTestId("round-type-public");
+    fireEvent.click(roundTypeOption);
 
     /* Trigger validation */
     fireEvent.click(screen.getByText("Next"));

--- a/packages/round-manager/src/test-utils.tsx
+++ b/packages/round-manager/src/test-utils.tsx
@@ -74,6 +74,7 @@ export const makeRoundData = (overrides: Partial<Round> = {}): Round => {
     roundMetadata: {
       name: faker.company.name(),
       programContractAddress: faker.finance.ethereumAddress(),
+      roundType: "private",
       quadraticFundingConfig: {
         matchingCap: true,
         matchingCapAmount: 100,


### PR DESCRIPTION
<!-- 
Thank you for your pull request! Please review the requirements below 
and ensure your pull request has fulfilled all requirements outlined in the target package.
-->

##### Description

As a Program Manager
I want to make my round public or private
So that I can choose if I want my round to be visible on the Explorer homepage

##### Refers/Fixes

fixes #1651 

##### Testing

<!-- All PRs should be accompanied by tests! If you haven't added tests, please explain here. -->
