### PR TITLE
Fund Grantees Fixes

### DIFF
--- a/packages/round-manager/src/features/round/ViewFundGrantees.tsx
+++ b/packages/round-manager/src/features/round/ViewFundGrantees.tsx
@@ -341,7 +341,7 @@ export function PayProjectsTable(props: { projects: MatchingStatsData[], token: 
                 <tbody className="divide-y divide-gray-200 bg-white">
                   {props.projects.map((project: MatchingStatsData) => (
                     <tr
-                      key={project.projectPayoutAddress}
+                      key={project.projectId}
                       className={
                         selectedProjects.includes(project)
                           ? "bg-gray-50"

--- a/packages/round-manager/src/features/round/ViewFundGrantees.tsx
+++ b/packages/round-manager/src/features/round/ViewFundGrantees.tsx
@@ -390,7 +390,7 @@ export function PayProjectsTable(props: { projects: MatchingStatsData[], token: 
                         {" " + props.token.name.toUpperCase()}
                         {Boolean(props.price) && " ($" +
                           formatCurrency(
-                            project.matchAmountInToken.mul(props.price * 100).div(100),
+                            project.matchAmountInToken.mul(Math.trunc(props.price * 10000)).div(10000),
                             props.token.decimal, 2)
                           + " USD) "}
                       </td>

--- a/packages/round-manager/src/features/round/ViewFundGrantees.tsx
+++ b/packages/round-manager/src/features/round/ViewFundGrantees.tsx
@@ -556,7 +556,7 @@ export function PaidProjectsTable(props: {
                         {" " + props.token.name.toUpperCase()}
                         {Boolean(props.price) && " ($" +
                           formatCurrency(
-                            project.matchAmountInToken.mul(props.price * 100).div(100),
+                            project.matchAmountInToken.mul(Math.trunc(props.price * 10000)).div(10000),
                             props.token.decimal, 2)
                           + " USD) "}
                       </td>

--- a/packages/round-manager/src/features/round/ViewRoundResults/ViewRoundResults.tsx
+++ b/packages/round-manager/src/features/round/ViewRoundResults/ViewRoundResults.tsx
@@ -356,7 +356,9 @@ export default function ViewRoundResults() {
         projectPayoutAddress: match.payoutAddress,
         applicationId: match.applicationId,
         projectId: match.projectId,
-        matchPoolPercentage: 0,
+        matchPoolPercentage:
+          Number((BigInt(1000000) * match.revisedMatch) / round.matchAmount) /
+          1000000,
         projectName: match.projectName,
         matchAmountInToken: BigNumber.from(match.revisedMatch),
         originalMatchAmountInToken: BigNumber.from(match.matched),
@@ -562,6 +564,7 @@ export default function ViewRoundResults() {
                                     (BigInt(1000000) * match.revisedMatch) /
                                       round.matchAmount
                                   ) / 10000;
+
                                 return (
                                   <tr key={match.applicationId}>
                                     <td className="text-sm leading-5 py-2 pr-2 text-gray-400 text-left text-ellipsis overflow-hidden whitespace-nowrap">


### PR DESCRIPTION
<!-- 
Thank you for your pull request! Please review the requirements below 
and ensure your pull request has fulfilled all requirements outlined in the target package.
-->

##### Description

I noticed we're using the match percentage in the Fund grantees page: https://github.com/gitcoinco/grants-stack/blob/0e74007cff1b29d130c160dfe402ece47c758a48/packages/round-manager/src/features/round/ViewFundGrantees.tsx#L386

I would rather calculate it using the round Match amount but this should suffice for now.

This also fixes the USD conversion.

<!-- Describe your changes here. -->

##### Refers/Fixes

<!-- If this PR is related to a GitHub issue, please add a link here. -->

##### Testing

<!-- All PRs should be accompanied by tests! If you haven't added tests, please explain here. -->
