### PR TITLE
enable rolling rounds

### DIFF
--- a/packages/round-manager/src/features/round/RoundDetailForm.tsx
+++ b/packages/round-manager/src/features/round/RoundDetailForm.tsx
@@ -388,7 +388,7 @@ export function RoundDetailForm(props: RoundDetailFormProps) {
                             className:
                               "block w-full border-0 p-0 text-gray-900 placeholder-grey-400 focus:ring-0 text-sm",
                           }}
-                          isValidDate={disableBeforeApplicationEndDate}
+                          isValidDate={disableBeforeApplicationStartDate}
                           utc={true}
                           dateFormat={"YYYY-MM-DD"}
                           timeFormat={"HH:mm UTC"}


### PR DESCRIPTION
This is a change to the grants stack round application that will enable applications to a round AFTER the crowdfund portion of the round has started.

This change will enable round operators to run rolling rounds (eg rounds where applications can be accepted after the crowdfund has started).  If this was available to me when we were running the metacrisis round, then we would not have had as many grant owners who missed the round because they didnt realize the deadline until too late.  I also ran into a similar situation with the Metacamp 2023 round wherein ppl asked to be included AFTER the round had already started.

I asked nate about this and he said "This design decision really stemmed from a desire to make the rounds legitimate / fair — we thought that allowing late acceptances would disadvantage those late grantees,".  IMO that is a good consideration, and perhaps there is an opportunity to educate round operators here about the tradeoffs of rolling rounds.  But I dont think a paternalistic "dont do this, its entirely disabled" is the answer.  So thats why I'm opening this PR.

Up to Gitcoin whether they want to merge this or not.  I would very much like to be able to run rolling rounds though.