### PR TITLE
updated cart icon and styles to fix alignment

### DIFF
--- a/packages/grant-explorer/src/features/common/NavbarCart.tsx
+++ b/packages/grant-explorer/src/features/common/NavbarCart.tsx
@@ -42,10 +42,20 @@ export default function NavbarCart(props: {
 }
 
 function QuickViewIcon(props: { count: number }) {
-  const badgeStyles =
-    props.count >= 100
-      ? { width: 6, paddingRight: 2.5 }
-      : { width: 4, paddingRight: 1.5 };
+  const Badge = tw.div`
+      inline-flex
+      absolute
+      justify-center
+      items-center
+      h-4
+      text-xs
+      text-white
+      bg-violet-400
+      rounded-full
+      -top-1.5
+      ${() => (props.count >= 100 ? "-right-2.5" : "-right-1.5")}
+      ${() => (props.count >= 100 ? "w-6" : "w-4")}
+    `;
 
   return (
     <div className="cursor-pointer">
@@ -66,15 +76,14 @@ function QuickViewIcon(props: { count: number }) {
       </svg>
 
       {props.count > 0 && (
-        <div
-          className={`inline-flex absolute justify-center items-center w-${badgeStyles.width} h-4 text-xs text-white bg-violet-400 rounded-full -top-1.5 -right-${badgeStyles.paddingRight}`}
+        <Badge
           style={{
             fontSize: "0.5rem",
             paddingLeft: 1,
           }}
         >
           {props.count}
-        </div>
+        </Badge>
       )}
     </div>
   );

--- a/packages/grant-explorer/src/features/common/NavbarCart.tsx
+++ b/packages/grant-explorer/src/features/common/NavbarCart.tsx
@@ -42,36 +42,41 @@ export default function NavbarCart(props: {
 }
 
 function QuickViewIcon(props: { count: number }) {
+  const badgeStyles =
+    props.count >= 100
+      ? { width: 6, paddingRight: 2.5 }
+      : { width: 4, paddingRight: 1.5 };
+
   return (
-    <>
+    <div className="cursor-pointer">
       <svg
-        width="26"
-        height="26"
-        viewBox="0 0 26 26"
+        width="20"
+        height="20"
+        viewBox="0 0 20 20"
         fill="none"
         xmlns="http://www.w3.org/2000/svg"
       >
         <path
-          d="M1 7H3L3.4 9M5 17H15L19 9H3.4M5 17L3.4 9M5 17L2.70711 19.2929C2.07714 19.9229 2.52331 21 3.41421 21H15M15 21C13.8954 21 13 21.8954 13 23C13 24.1046 13.8954 25 15 25C16.1046 25 17 24.1046 17 23C17 21.8954 16.1046 21 15 21ZM7 23C7 24.1046 6.10457 25 5 25C3.89543 25 3 24.1046 3 23C3 21.8954 3.89543 21 5 21C6.10457 21 7 21.8954 7 23Z"
+          d="M1 1H3L3.4 3M5 11H15L19 3H3.4M5 11L3.4 3M5 11L2.70711 13.2929C2.07714 13.9229 2.52331 15 3.41421 15H15M15 15C13.8954 15 13 15.8954 13 17C13 18.1046 13.8954 19 15 19C16.1046 19 17 18.1046 17 17C17 15.8954 16.1046 15 15 15ZM7 17C7 18.1046 6.10457 19 5 19C3.89543 19 3 18.1046 3 17C3 15.8954 3.89543 15 5 15C6.10457 15 7 15.8954 7 17Z"
           stroke="#0E0333"
           strokeWidth="2"
           strokeLinecap="round"
           strokeLinejoin="round"
         />
-        {props.count ? <circle cx="18" cy="8" r="8" fill="#6F3FF5" /> : null}
       </svg>
 
-      {Boolean(props.count) && (
+      {props.count > 0 && (
         <div
-          className="inline-flex absolute top-0.5 pt-0.5 pl-1 left-2 justify-center items-center w-4 h-3 text-white"
+          className={`inline-flex absolute justify-center items-center w-${badgeStyles.width} h-4 text-xs text-white bg-violet-400 rounded-full -top-1.5 -right-${badgeStyles.paddingRight}`}
           style={{
-            fontSize: 7.5,
+            fontSize: "0.5rem",
+            paddingLeft: 1,
           }}
         >
           {props.count}
         </div>
       )}
-    </>
+    </div>
   );
 }
 


### PR DESCRIPTION
closes #1545 

* Re-exported original cart svg to avoid having always a space on top even without items in the cart
* Updated badge position with negative numbers to keep the cart icon always centered
* Moved badge background outside the svg, with just css
* Set higher badge width when count is > 99

Before:

<img width="640" alt="cart-0" src="https://github.com/gitcoinco/grants-stack/assets/1059/e2913604-f340-4f65-8007-5d83559d270b">

---------------

Now with 0, 1, 10, 100 items:


<img width="640" alt="cart-z" src="https://github.com/gitcoinco/grants-stack/assets/1059/9aee5672-b1cd-491f-a518-51f5c6936dd3">


<img width="640" alt="cart-1" src="https://github.com/gitcoinco/grants-stack/assets/1059/1d9b4275-0e70-4423-81b2-04eaaaf4aadf">

<img width="640" alt="cart-10" src="https://github.com/gitcoinco/grants-stack/assets/1059/b536880e-84b9-40d7-a03a-14de2d4169e2">

<img width="640" alt="cart-100" src="https://github.com/gitcoinco/grants-stack/assets/1059/6de4b8df-6358-4cbf-9b7c-411448caa704">

