### PR TITLE
[1869] chore: clean up explorer landing page

### DIFF
--- a/packages/grant-explorer/src/features/api/rounds.ts
+++ b/packages/grant-explorer/src/features/api/rounds.ts
@@ -12,7 +12,10 @@ interface GetRoundOverviewResult {
 const validRounds = [
   "0x35c9d05558da3a3f3cddbf34a8e364e59b857004",
   "0x984e29dcb4286c2d9cbaa2c238afdd8a191eefbc",
+  "0x4195cd3cd76cc13faeb94fdad66911b4e0996f38",
 ];
+
+const invalidRounds = ["0xde272b1a1efaefab2fd168c02b8cf0e3b10680ef"];
 
 export type RoundOverview = {
   id: string;
@@ -66,6 +69,14 @@ async function fetchRoundsByTimestamp(
       // check if round.id is in validRounds & if so, add to filteredRounds
       if (validRounds.includes(round.id)) {
         filteredRounds.push(round);
+      }
+
+      // check if round.id is in invalidRounds & if so, remove from filteredRounds
+      if (invalidRounds.includes(round.id)) {
+        const index = filteredRounds.findIndex((r) => r.id === round.id);
+        if (index > -1) {
+          filteredRounds.splice(index, 1);
+        }
       }
     }
 

--- a/packages/grant-explorer/src/features/discovery/LandingPage.tsx
+++ b/packages/grant-explorer/src/features/discovery/LandingPage.tsx
@@ -1,16 +1,16 @@
+import Footer from "common/src/components/Footer";
 import { lazy, Suspense, useEffect, useState } from "react";
-
-const LandingBannerLogo = lazy(() => import("../../assets/LandingBanner"));
 import {
-  RoundOverview,
   getActiveRounds,
   getRoundsInApplicationPhase,
+  RoundOverview,
 } from "../api/rounds";
+import { useDebugMode } from "../api/utils";
 import Navbar from "../common/Navbar";
 import ActiveRoundsSection from "./ActiveRoundSection";
 import ApplyNowSection from "./ApplyNowSection";
-import { useDebugMode } from "../api/utils";
-import Footer from "common/src/components/Footer";
+
+const LandingBannerLogo = lazy(() => import("../../assets/LandingBanner"));
 
 const LandingPage = () => {
   const [searchQuery, setSearchQuery] = useState("");


### PR DESCRIPTION

##### Description

Cleans up the explorer landing page:
- Add [Greenpill Q2 2023 round](https://explorer.gitcoin.co/#/round/10/0x4195cd3cd76cc13faeb94fdad66911b4e0996f38) (confirmed real round)
- Hide [Meg's test round](https://explorer.gitcoin.co/#/round/10/0xde272b1a1efaefab2fd168c02b8cf0e3b10680ef)

##### Refers/Fixes

Closes #1869 

##### Testing

Tested locally

![mr-clean-dancing](https://github.com/gitcoinco/grants-stack/assets/129965/8fa27650-dea0-4a81-952e-6c31a96519f9)