### PR TITLE
fix: make the application preview scroll to top

### DIFF
--- a/packages/builder/src/components/application/Form.tsx
+++ b/packages/builder/src/components/application/Form.tsx
@@ -263,6 +263,10 @@ function FullPreview(props: {
   } = props;
   const ipfsPrefix = `${process.env.REACT_APP_PINATA_GATEWAY!}/ipfs/`;
 
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, []);
+
   return (
     <>
       <div className="relative pt-7">


### PR DESCRIPTION
##### Description

Could not reproduce, added a `useEffect` to scroll to the top of the window after the page has rendered.

##### Refers/Fixes

#1527 

