### PR TITLE
[1840] Manager: allow applications and round period to overlap

### DIFF
--- a/packages/round-manager/src/features/round/RoundDetailForm.tsx
+++ b/packages/round-manager/src/features/round/RoundDetailForm.tsx
@@ -177,13 +177,6 @@ export function RoundDetailForm(props: RoundDetailFormProps) {
     return disablePastDate(current);
   };
 
-  function disableBeforeApplicationEndDate(current: moment.Moment) {
-    if (rollingApplications) {
-      return disableBeforeApplicationStartDate(current);
-    }
-    return current.isAfter(applicationEndDate);
-  }
-
   function disableBeforeRoundStartDate(current: moment.Moment) {
     return current.isAfter(roundStartDate);
   }
@@ -462,7 +455,7 @@ export function RoundDetailForm(props: RoundDetailFormProps) {
                             className:
                               "block w-full border-0 p-0 text-gray-900 placeholder-grey-400 focus:ring-0 text-sm",
                           }}
-                          isValidDate={disableBeforeApplicationEndDate}
+                          isValidDate={disableBeforeApplicationStartDate}
                           utc={true}
                           dateFormat={"YYYY-MM-DD"}
                           timeFormat={"HH:mm UTC"}

--- a/packages/round-manager/src/features/round/RoundDetailForm.tsx
+++ b/packages/round-manager/src/features/round/RoundDetailForm.tsx
@@ -143,7 +143,7 @@ export function RoundDetailForm(props: RoundDetailFormProps) {
 
   const FormStepper = props.stepper;
   const [applicationStartDate, setApplicationStartDate] = useState(moment());
-  const [applicationEndDate, setApplicationEndDate] = useState(moment());
+  const [, setApplicationEndDate] = useState(moment());
   const [roundStartDate, setRoundStartDate] = useState(moment());
   const [roundEndDate, setRoundEndDate] = useState<moment.Moment | "">("");
   const [rollingApplications, setRollingApplications] = useState(false);

--- a/packages/round-manager/src/features/round/RoundDetailForm.tsx
+++ b/packages/round-manager/src/features/round/RoundDetailForm.tsx
@@ -178,6 +178,9 @@ export function RoundDetailForm(props: RoundDetailFormProps) {
   };
 
   function disableBeforeApplicationEndDate(current: moment.Moment) {
+    if (rollingApplications) {
+      return disableBeforeApplicationStartDate(current);
+    }
     return current.isAfter(applicationEndDate);
   }
 
@@ -188,6 +191,7 @@ export function RoundDetailForm(props: RoundDetailFormProps) {
   useEffect(() => {
     if (rollingApplications && roundEndDate !== "") {
       setValue("applicationsEndTime", roundEndDate.toDate());
+      setApplicationEndDate(roundEndDate);
     }
   }, [rollingApplications, roundEndDate, setValue]);
 
@@ -518,6 +522,7 @@ export function RoundDetailForm(props: RoundDetailFormProps) {
                             field.onChange(moment(date));
                             setRoundEndDate(moment(date));
                             if (rollingApplications) {
+                              setApplicationEndDate(moment(date));
                               setValue(
                                 "applicationsEndTime",
                                 moment(date).toDate()

--- a/packages/round-manager/src/features/round/RoundDetailForm.tsx
+++ b/packages/round-manager/src/features/round/RoundDetailForm.tsx
@@ -82,19 +82,13 @@ export const RoundValidationSchema = yup.object().shape({
       yup.ref("roundEndTime"),
       "Applications start date must be before the round end date."
     ),
-  rollingApplications: yup.boolean(),
   applicationsEndTime: yup
     .date()
     .required("This field is required.")
-    .when("rollingApplications", {
-      is: false,
-      then: yup
-        .date()
-        .min(
-          yup.ref("applicationsStartTime"),
-          "Applications end date must be later than applications start date."
-        ),
-    })
+    .min(
+      yup.ref("applicationsStartTime"),
+      "Applications end date must be later than applications start date."
+    )
     .max(
       yup.ref("roundEndTime"),
       "Applications end date must be before the round end date."

--- a/packages/round-manager/src/features/round/RoundDetailForm.tsx
+++ b/packages/round-manager/src/features/round/RoundDetailForm.tsx
@@ -328,7 +328,7 @@ export function RoundDetailForm(props: RoundDetailFormProps) {
                       htmlFor="rollingApplications"
                       className="ml-2 block text-sm text-grey-400"
                     >
-                      Accept applications throughout round
+                      Enable rolling applications
                     </label>
                     <InformationCircleIcon
                       data-tip

--- a/packages/round-manager/src/features/round/RoundDetailForm.tsx
+++ b/packages/round-manager/src/features/round/RoundDetailForm.tsx
@@ -145,7 +145,7 @@ export function RoundDetailForm(props: RoundDetailFormProps) {
   const [applicationStartDate, setApplicationStartDate] = useState(moment());
   const [applicationEndDate, setApplicationEndDate] = useState(moment());
   const [roundStartDate, setRoundStartDate] = useState(moment());
-  const [roundEndDate, setRoundEndDate] = useState(moment());
+  const [roundEndDate, setRoundEndDate] = useState<moment.Moment | "">("");
   const [rollingApplications, setRollingApplications] = useState(false);
 
   const next: SubmitHandler<Round> = async (values) => {
@@ -186,7 +186,7 @@ export function RoundDetailForm(props: RoundDetailFormProps) {
   }
 
   useEffect(() => {
-    if (rollingApplications) {
+    if (rollingApplications && roundEndDate !== "") {
       setValue("applicationsEndTime", roundEndDate.toDate());
     }
   }, [rollingApplications, roundEndDate, setValue]);


### PR DESCRIPTION
### Description

Changes round creation behaviour as per [Figma](https://www.figma.com/file/V113F2Pp5m2qDM5odXjfFu/Manager-S17?type=design&node-id=2058%3A44553&t=72M3DAIH6udXhBQJ-1) and [Loom walkthrough](https://www.loom.com/share/0088cad637a14e86bbbda735a32da47b).
@willsputra I added a tooltip as well, let me know if you want me to remove it.

### Refers/Fixes

Fixes #1840 
