### PR TITLE
fix: builder project preview

### DIFF
--- a/packages/builder/src/components/grants/About.tsx
+++ b/packages/builder/src/components/grants/About.tsx
@@ -165,12 +165,11 @@ export default function About({
           </div>
         )}
         <div className="mt-4">
-          <p className="text-primary-text ml-2 xl:mt-2 lg:mt-2 font-bold">
-            Description
-          </p>
-          <div className="pt-6 mb-12 ml-2 prose prose-h1:text-lg prose-h2:text-base prose-h3:text-base prose-a:text-blue-600">
+          <div className="mb-12 ml-2 prose prose-h1:text-lg prose-h2:text-base prose-h3:text-base prose-a:text-blue-600">
+            <div className="text-sm">Description</div>
             {project?.description && (
               <div
+                className="pr-4"
                 // eslint-disable-next-line react/no-danger
                 dangerouslySetInnerHTML={{
                   __html: renderToHTML(

--- a/packages/builder/src/components/grants/Details.tsx
+++ b/packages/builder/src/components/grants/Details.tsx
@@ -56,7 +56,7 @@ export default function Details({
         bannerImg={bannerImg}
         logoImg={logoImg}
       />
-      {showTabs && (
+      {showTabs ? (
         <Tabs className="mt-8" defaultIndex={0}>
           <TabList className="mb-12" width="fit-content">
             <Tab
@@ -107,6 +107,13 @@ export default function Details({
             </TabPanel>
           </TabPanels>
         </Tabs>
+      ) : (
+        <About
+          project={project}
+          showApplications={showApplications}
+          createdAt={createdAt}
+          updatedAt={updatedAt}
+        />
       )}
     </>
   );

--- a/packages/builder/tailwind.config.js
+++ b/packages/builder/tailwind.config.js
@@ -44,6 +44,15 @@ module.exports = {
     fontFamily: {
       sans: ['"Libre Franklin"'],
     },
+    typography: (theme) => ({
+      DEFAULT: {
+        css: {
+          'p': {
+            paddingTop: '8px',
+          },
+        },
+      },
+    }),
   },
   important: true,
   plugins: [

--- a/packages/builder/tailwind.config.js
+++ b/packages/builder/tailwind.config.js
@@ -44,18 +44,7 @@ module.exports = {
     fontFamily: {
       sans: ['"Libre Franklin"'],
     },
-    typography: (theme) => ({
-      DEFAULT: {
-        css: {
-          'p': {
-            paddingTop: '8px',
-          },
-        },
-      },
-    }),
   },
   important: true,
-  plugins: [
-    require("@tailwindcss/typography"),
-  ],
+  plugins: [require("@tailwindcss/typography")],
 };


### PR DESCRIPTION
fixes #1891 By restructuring the `showTabs` boolean logic. If true, the about section will be shown inside of the navigable tab panel, otherwise just show the about section (e.g. when previewing). 