### PR TITLE
Explorer: Implement Past and Active round split on Donation History page

### DIFF
--- a/packages/grant-explorer/src/assets/DonationHistoryBanner.tsx
+++ b/packages/grant-explorer/src/assets/DonationHistoryBanner.tsx
@@ -1,0 +1,6 @@
+import { ReactComponent as DonationHistoryBanner } from "./donnation-history-banner.svg";
+import { ComponentProps } from "react";
+
+export default (props: ComponentProps<"svg">) => (
+  <DonationHistoryBanner {...props} />
+);

--- a/packages/grant-explorer/src/features/api/utils.ts
+++ b/packages/grant-explorer/src/features/api/utils.ts
@@ -407,3 +407,16 @@ export const listenForOutsideClicks = ({
     });
   };
 };
+
+export function getChainIds(): number[] {
+  const isProduction = process.env.REACT_APP_ENV === "production";
+  if (isProduction) {
+    return [
+      Number(ChainId.MAINNET),
+      Number(ChainId.OPTIMISM_MAINNET_CHAIN_ID),
+      Number(ChainId.FANTOM_MAINNET_CHAIN_ID),
+    ];
+  } else {
+    return Object.values(ChainId).map((chainId) => Number(chainId));
+  }
+}

--- a/packages/grant-explorer/src/features/common/StatCard.tsx
+++ b/packages/grant-explorer/src/features/common/StatCard.tsx
@@ -1,0 +1,8 @@
+export function StatCard(props: { title: string; value: string | undefined }) {
+  return (
+    <div className="rounded border border-violet-400 p-4">
+      <div className="font-bold text-md pb-4">{props.title}</div>
+      <div className="text-grey-400 text-2xl">{props.value}</div>
+    </div>
+  );
+}

--- a/packages/grant-explorer/src/features/contributors/ViewContributionHistory.tsx
+++ b/packages/grant-explorer/src/features/contributors/ViewContributionHistory.tsx
@@ -300,7 +300,7 @@ function DonationsTable(props: {
             </div>
           </th>
           <th className="py-4 text-right w-1/3 lg:w-1/4 font-medium">
-            Transaction information
+            Transaction Information
           </th>
         </tr>
         {props.contributions.length > 0 &&

--- a/packages/grant-explorer/src/features/contributors/ViewContributionHistory.tsx
+++ b/packages/grant-explorer/src/features/contributors/ViewContributionHistory.tsx
@@ -184,7 +184,7 @@ export function ViewContributionHistoryDisplay(props: {
         </div>
         <div className="text-2xl my-6">Donation History</div>
         <div className="text-lg bg-violet-100 text-black px-1 py-1 mb-2">
-          All Rounds
+          Active Rounds
         </div>
         <table
           className="border-collapse w-full"
@@ -282,6 +282,9 @@ export function ViewContributionHistoryDisplay(props: {
             });
           })}
         </table>
+        <div className="text-lg bg-grey-100 text-black px-1 py-1 mb-2">
+          Past Rounds
+        </div>
       </main>
       <div className="mt-24 mb-11 h-11">
         <Footer />

--- a/packages/grant-explorer/src/features/contributors/ViewContributionHistory.tsx
+++ b/packages/grant-explorer/src/features/contributors/ViewContributionHistory.tsx
@@ -22,6 +22,7 @@ import { payoutTokens } from "../api/utils";
 import { ArrowTopRightOnSquareIcon } from "@heroicons/react/24/outline";
 import { Button } from "common/src/styles";
 import ReactTooltip from "react-tooltip";
+import Breadcrumb, { BreadcrumbItem } from "../common/Breadcrumb";
 
 type ContributionHistoryState =
   | { type: "loading" }
@@ -116,6 +117,7 @@ export function ViewContributionHistoryDisplay(props: {
   address: string;
   addressLogo: string;
   ensName?: string;
+  breadCrumbs: BreadcrumbItem[];
 }) {
   const currentOrigin = window.location.origin;
 
@@ -187,6 +189,9 @@ export function ViewContributionHistoryDisplay(props: {
 
   return (
     <div className="relative top-16 lg:mx-20 xl:mx-20 px-4 py-7 h-screen">
+      <div className="flex flex-col pb-4" data-testid="bread-crumbs">
+        <Breadcrumb items={props.breadCrumbs} />
+      </div>
       <main>
         <div className="border-b pb-2 mb-4 flex items-center justify-between">
           <div className="flex items-center">
@@ -383,11 +388,15 @@ export function ViewContributionHistoryWithoutDonations(props: {
   address: string;
   addressLogo: string;
   ensName?: string;
+  breadCrumbs: BreadcrumbItem[];
 }) {
   const currentOrigin = window.location.origin;
   const { address: walletAddress } = useAccount();
   return (
     <div className="relative top-16 lg:mx-20 px-4 py-7 h-screen">
+      <div className="flex flex-col pb-4" data-testid="bread-crumbs">
+        <Breadcrumb items={props.breadCrumbs} />
+      </div>
       <main>
         <div className="border-b pb-2 mb-4 flex items-center justify-between">
           <div className="flex items-center">
@@ -464,6 +473,17 @@ function ViewContributionHistoryFetcher(props: {
     props.address
   );
 
+  const breadCrumbs = [
+    {
+      name: "Explorer Home",
+      path: "/",
+    },
+    {
+      name: "Contributors",
+      path: `/contributors/${props.address}`,
+    },
+  ] as BreadcrumbItem[];
+
   const addressLogo = useMemo(() => {
     return blockies.create({ seed: props.address.toLowerCase() }).toDataURL();
   }, [props.address]);
@@ -480,6 +500,7 @@ function ViewContributionHistoryFetcher(props: {
       <ViewContributionHistoryWithoutDonations
         address={props.address}
         addressLogo={addressLogo}
+        breadCrumbs={breadCrumbs}
       />
     );
   } else {
@@ -489,6 +510,7 @@ function ViewContributionHistoryFetcher(props: {
         addressLogo={addressLogo}
         contributions={contributionHistory.data}
         address={props.address}
+        breadCrumbs={breadCrumbs}
       />
     );
   }

--- a/packages/grant-explorer/src/features/contributors/ViewContributionHistory.tsx
+++ b/packages/grant-explorer/src/features/contributors/ViewContributionHistory.tsx
@@ -239,7 +239,7 @@ export function ViewContributionHistoryDisplay(props: {
           </div>
         </div>
         <div className="text-2xl my-6">Donation History</div>
-        <div className="text-lg bg-violet-100 text-black px-1 py-1 mb-2">
+        <div className="text-lg bg-violet-100 text-black px-1 py-1 mb-2 font-semibold">
           Active Rounds
         </div>
         <DonationsTable
@@ -247,7 +247,7 @@ export function ViewContributionHistoryDisplay(props: {
           tokens={props.tokens}
           activeRound={true}
         />
-        <div className="text-lg bg-grey-100 text-black px-1 py-1 mb-2">
+        <div className="text-lg bg-grey-100 text-black px-1 py-1 mb-2 font-semibold">
           Past Rounds
         </div>
         <DonationsTable
@@ -275,8 +275,8 @@ function DonationsTable(props: {
         data-testid="donation-history-table"
       >
         <tr className="text-left text-lg">
-          <th className="py-4 w-1/3 lg:w-1/2">Project</th>
-          <th className="flex flex-row py-4 w-1/3 lg:w-1/4">
+          <th className="py-4 w-1/3 lg:w-1/2 font-medium">Project</th>
+          <th className="flex flex-row py-4 w-1/3 lg:w-1/4 font-medium">
             <div className="py-4">Donation</div>
             <div className="py-4">
               <InformationCircleIcon
@@ -299,7 +299,7 @@ function DonationsTable(props: {
               </ReactTooltip>
             </div>
           </th>
-          <th className="py-4 text-right w-1/3 lg:w-1/4">
+          <th className="py-4 text-right w-1/3 lg:w-1/4 font-medium">
             Transaction information
           </th>
         </tr>

--- a/packages/grant-explorer/src/features/contributors/ViewContributionHistory.tsx
+++ b/packages/grant-explorer/src/features/contributors/ViewContributionHistory.tsx
@@ -7,13 +7,16 @@ import {
   ChevronRightIcon,
   InformationCircleIcon,
 } from "@heroicons/react/24/solid";
-import { useEffect, useMemo, useState } from "react";
+import { lazy, useEffect, useMemo, useState } from "react";
 import { Link, useParams } from "react-router-dom";
 import { ethers } from "ethers";
 import { PayoutToken } from "../api/types";
 import { CHAINS, getTxExplorer } from "../api/utils";
 import Navbar from "../common/Navbar";
-import { ReactComponent as DonationHistoryBanner } from "../../assets/donnation-history-banner.svg";
+// import { ReactComponent as DonationHistoryBanner } from "../../assets/donnation-history-banner.svg";
+const DonationHistoryBanner = lazy(
+  () => import("../../assets/DonationHistoryBanner")
+);
 import { ChainId } from "../api/utils";
 import blockies from "ethereum-blockies";
 import CopyToClipboardButton from "../common/CopyToClipboardButton";
@@ -104,7 +107,7 @@ const useContributionHistory = (chainIds: number[], rawAddress: string) => {
 
 function StatCard(props: { title: string; value: string | undefined }) {
   return (
-    <div className="rounded border border-violet-400 p-4 flex-grow">
+    <div className="rounded border border-violet-400 p-4">
       <div className="font-bold text-md pb-4">{props.title}</div>
       <div className="text-grey-400 text-2xl">{props.value}</div>
     </div>
@@ -201,7 +204,7 @@ export function ViewContributionHistoryDisplay(props: {
               alt="Address Logo"
             />
             <div
-              className="text-[32px]"
+              className="text-[18px] lg:text-[32px]"
               data-testid="contributor-address"
               title={props.address}
             >
@@ -216,19 +219,25 @@ export function ViewContributionHistoryDisplay(props: {
           />
         </div>
         <div className="text-2xl my-6">Donation Impact</div>
-        <div className="flex gap-4 my-4">
-          <StatCard
-            title="Total Donations"
-            value={"$ " + totalDonations.toFixed(2).toString()}
-          />
-          <StatCard
-            title="Unique Contributions"
-            value={totalUniqueContributions.toString()}
-          />
-          <StatCard
-            title="Projects Funded"
-            value={totalProjectsFunded.toString()}
-          />
+        <div className="grid grid-cols-2 grid-row-2 lg:grid-cols-3 lg:grid-row-1 gap-4">
+          <div className="col-span-2 lg:col-span-1">
+            <StatCard
+              title="Total Donations"
+              value={"$ " + totalDonations.toFixed(2).toString()}
+            />
+          </div>
+          <div className="col-span-1">
+            <StatCard
+              title="Contributions"
+              value={totalUniqueContributions.toString()}
+            />
+          </div>
+          <div className="col-span-1">
+            <StatCard
+              title="Projects Funded"
+              value={totalProjectsFunded.toString()}
+            />
+          </div>
         </div>
         <div className="text-2xl my-6">Donation History</div>
         <div className="text-lg bg-violet-100 text-black px-1 py-1 mb-2">
@@ -261,110 +270,118 @@ function DonationsTable(props: {
   activeRound: boolean;
 }) {
   return (
-    <table
-      className="border-collapse w-full"
-      data-testid="donation-history-table"
-    >
-      <tr className="text-left text-lg">
-        <th className="py-4 w-1/2">Project</th>
-        <th className="flex flex-row py-4 w-1/4">
-          Donation
-          <InformationCircleIcon
-            data-tip
-            data-background-color="#0E0333"
-            data-for="donation-tooltip"
-            className="inline h-4 w-4 ml-2 mr-3 mt-1.5"
-            data-testid={"donation-tooltip"}
-          />
-          <ReactTooltip
-            id="donation-tooltip"
-            place="bottom"
-            type="dark"
-            effect="solid"
-          >
-            <p className="text-xs">
-              The displayed amount in USD reflects <br />
-              the value at the time of your donation.
-            </p>
-          </ReactTooltip>
-        </th>
-        <th className="py-4 text-right w-1/4">Transaction information</th>
-      </tr>
-      {props.contributions.length > 0 ? (
-        props.contributions.map((chainContribution) => {
-          const { chainId, data } = chainContribution;
-          return data.map((contribution) => {
-            const token = props.tokens[contribution.token];
+    <>
+      <table
+        className="border-collapse w-full"
+        data-testid="donation-history-table"
+      >
+        <tr className="text-left text-lg">
+          <th className="py-4 w-1/3 lg:w-1/2">Project</th>
+          <th className="flex flex-row py-4 w-1/3 lg:w-1/4">
+            <div className="py-4">Donation</div>
+            <div className="py-4">
+              <InformationCircleIcon
+                data-tip
+                data-background-color="#0E0333"
+                data-for="donation-tooltip"
+                className="inline h-4 w-4 ml-2 mr-3"
+                data-testid={"donation-tooltip"}
+              />
+              <ReactTooltip
+                id="donation-tooltip"
+                place="bottom"
+                type="dark"
+                effect="solid"
+              >
+                <p className="text-xs">
+                  The displayed amount in USD reflects <br />
+                  the value at the time of your donation.
+                </p>
+              </ReactTooltip>
+            </div>
+          </th>
+          <th className="py-4 text-right w-1/3 lg:w-1/4">
+            Transaction information
+          </th>
+        </tr>
+        {props.contributions.length > 0 &&
+          props.contributions.map((chainContribution) => {
+            const { chainId, data } = chainContribution;
+            return data.map((contribution) => {
+              const token = props.tokens[contribution.token];
 
-            let formattedAmount = "N/A";
+              let formattedAmount = "N/A";
 
-            if (token) {
-              formattedAmount = `${ethers.utils.formatUnits(
-                contribution.amount,
-                token.decimal
-              )} ${token.name}`;
-            }
+              if (token) {
+                formattedAmount = `${ethers.utils.formatUnits(
+                  contribution.amount,
+                  token.decimal
+                )} ${token.name}`;
+              }
 
-            return (
-              <tr key={contribution.id}>
-                <td className="border-b py-4 pr-16 w-1/2">
-                  <div className="flex items-center">
-                    <div>
-                      <img
-                        className="w-4 h-4 mr-2"
-                        src={CHAINS[chainId]?.logo}
-                        alt="Round Chain Logo"
+              return (
+                <tr key={contribution.id}>
+                  <td className="border-b py-4 pr-2 lg:pr-16 w-1/3 lg:w-1/2">
+                    <div className="flex items-center">
+                      <div className="flex flex-col sm:flex-row">
+                        <div className="flex items-center">
+                          <img
+                            className="w-4 h-4 mr-2"
+                            src={CHAINS[chainId]?.logo}
+                            alt="Round Chain Logo"
+                          />
+                          <Link
+                            className={`underline inline-block lg:pr-2 lg:max-w-[200px] max-w-[75px] 2xl:max-w-fit truncate`}
+                            title={contribution.roundName}
+                            to={`/round/${chainId}/${contribution.roundId.toLowerCase()}`}
+                            target="_blank"
+                          >
+                            {contribution.roundName}
+                          </Link>
+                          <ChevronRightIcon className="h-4 inline lg:mx-2" />
+                        </div>
+                        <Link
+                          className={`underline inline-block lg:pr-2 lg:max-w-[300px] max-w-[75px] 2xl:max-w-fit truncate`}
+                          title={contribution.projectTitle}
+                          to={`/round/${chainId}/${contribution.roundId.toLowerCase()}/${contribution.roundId.toLowerCase()}-${
+                            contribution.applicationId
+                          }`}
+                          target="_blank"
+                        >
+                          {contribution.projectTitle}
+                        </Link>
+                      </div>
+                    </div>
+                    {/* Todo: display contribution timestamp */}
+                    {/* <div className="text-sm text-gray-500">4 mins ago</div> */}
+                  </td>
+                  <td className="border-b py-4 truncate lg:pr-16 w-1/3 lg:w-1/4">
+                    {formattedAmount}
+                    <div className="text-md text-gray-500">
+                      ${contribution.amountUSD.toFixed(2)}
+                    </div>
+                  </td>
+                  <td className="border-b py-4 lg:pr-12 w-1/3 lg:w-1/4">
+                    <div className="flex justify-end">
+                      <ViewTransactionButton
+                        chainId={chainId}
+                        txHash={contribution.transaction}
                       />
                     </div>
-                    <Link
-                      className={`underline inline-block pr-2 custom_lg:max-w-[200px] truncate`}
-                      title={contribution.roundName}
-                      to={`/round/${chainId}/${contribution.roundId.toLowerCase()}`}
-                      target="_blank"
-                    >
-                      {contribution.roundName}
-                    </Link>
-                    <ChevronRightIcon className="h-4 inline mx-2" />
-                    <Link
-                      className={`underline inline-block pr-2 custom_lg:max-w-[300px] truncate`}
-                      title={contribution.projectTitle}
-                      to={`/round/${chainId}/${contribution.roundId.toLowerCase()}/${contribution.roundId.toLowerCase()}-${
-                        contribution.applicationId
-                      }`}
-                      target="_blank"
-                    >
-                      {contribution.projectTitle}
-                    </Link>
-                  </div>
-                  {/* Todo: display contribution timestamp */}
-                  {/* <div className="text-sm text-gray-500">4 mins ago</div> */}
-                </td>
-                <td className="border-b py-4 truncate pr-16 w-1/4">
-                  {formattedAmount}
-                  <div className="text-md text-gray-500">
-                    ${contribution.amountUSD.toFixed(2)}
-                  </div>
-                </td>
-                <td className="border-b py-4 pr-12 w-1/4">
-                  <div className="flex justify-end">
-                    <ViewTransactionButton
-                      chainId={chainId}
-                      txHash={contribution.transaction}
-                    />
-                  </div>
-                </td>
-              </tr>
-            );
-          });
-        })
-      ) : (
-        <div className="text-md mt-2 mb-10">
+                  </td>
+                </tr>
+              );
+            });
+          })}
+      </table>
+      {props.contributions.length == 0 && (
+        <div className="text-md mt-2 mb-12">
           {props.activeRound
             ? "Donations made during active rounds will appear here."
             : "Donations made during past rounds will appear here."}
         </div>
       )}
-    </table>
+    </>
   );
 }
 
@@ -406,7 +423,7 @@ export function ViewContributionHistoryWithoutDonations(props: {
               alt="Address Logo"
             />
             <div
-              className="text-[32px]"
+              className="text-[18px] lg:text-[32px]"
               data-testid="contributor-address"
               title={props.address}
             >
@@ -454,7 +471,7 @@ export function ViewContributionHistoryWithoutDonations(props: {
         </div>
         <div className="flex justify-center">
           {" "}
-          <DonationHistoryBanner />
+          <DonationHistoryBanner className="w-full h-auto object-cover rounded-t" />
         </div>
       </main>
       <div className="mt-24 mb-11 h-11">

--- a/packages/grant-explorer/src/features/contributors/ViewContributionHistory.tsx
+++ b/packages/grant-explorer/src/features/contributors/ViewContributionHistory.tsx
@@ -13,7 +13,6 @@ import { ethers } from "ethers";
 import { PayoutToken } from "../api/types";
 import { CHAINS, getTxExplorer } from "../api/utils";
 import Navbar from "../common/Navbar";
-// import { ReactComponent as DonationHistoryBanner } from "../../assets/donnation-history-banner.svg";
 const DonationHistoryBanner = lazy(
   () => import("../../assets/DonationHistoryBanner")
 );

--- a/packages/grant-explorer/src/features/contributors/ViewContributionHistory.tsx
+++ b/packages/grant-explorer/src/features/contributors/ViewContributionHistory.tsx
@@ -495,7 +495,7 @@ function ViewContributionHistoryFetcher(props: {
       path: "/",
     },
     {
-      name: "Contributors",
+      name: "Profile",
       path: `/contributors/${props.address}`,
     },
   ] as BreadcrumbItem[];

--- a/packages/grant-explorer/src/features/contributors/__tests__/ViewContributionHistory.test.tsx
+++ b/packages/grant-explorer/src/features/contributors/__tests__/ViewContributionHistory.test.tsx
@@ -6,6 +6,7 @@ import {
 } from "../ViewContributionHistory";
 import { mockSigner } from "../../../test-utils";
 import { MemoryRouter } from "react-router-dom";
+import { BreadcrumbItem } from "../../common/Breadcrumb";
 
 const mockAddress = faker.finance.ethereumAddress();
 
@@ -75,6 +76,17 @@ const useParamsFn = () => ({
   address: mockAddress,
 });
 
+const breadCrumbs = [
+  {
+    name: "Explorer Home",
+    path: "/",
+  },
+  {
+    name: "Contributors",
+    path: `/contributors/${mockAddress}`,
+  },
+] as BreadcrumbItem[];
+
 Object.defineProperty(window, "scrollTo", { value: () => {}, writable: true });
 
 jest.mock("../../common/Navbar");
@@ -106,6 +118,7 @@ describe("<ViewContributionHistoryDisplay/>", () => {
           contributions={mockContributions}
           address={mockAddress}
           addressLogo="mockedAddressLogo"
+          breadCrumbs={breadCrumbs}
         />
       </MemoryRouter>
     );
@@ -146,6 +159,7 @@ describe("<ViewContributionHistoryWithoutDonations/>", () => {
         <ViewContributionHistoryWithoutDonations
           address={mockAddress}
           addressLogo="mockedAddressLogo"
+          breadCrumbs={breadCrumbs}
         />
       </MemoryRouter>
     );

--- a/packages/grant-explorer/src/features/contributors/__tests__/ViewContributionHistory.test.tsx
+++ b/packages/grant-explorer/src/features/contributors/__tests__/ViewContributionHistory.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import { faker } from "@faker-js/faker";
 import {
-  ViewContributionHistoryDisplay,
+  ViewContributionHistory,
   ViewContributionHistoryWithoutDonations,
 } from "../ViewContributionHistory";
 import { mockSigner } from "../../../test-utils";
@@ -105,7 +105,7 @@ jest.mock("wagmi", () => ({
   useAccount: jest.fn().mockReturnValue({ data: "mockedAccount" }),
 }));
 
-describe("<ViewContributionHistoryDisplay/>", () => {
+describe("<ViewContributionHistory/>", () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
@@ -113,7 +113,7 @@ describe("<ViewContributionHistoryDisplay/>", () => {
   it("Should show donation impact & donation history", async () => {
     render(
       <MemoryRouter>
-        <ViewContributionHistoryDisplay
+        <ViewContributionHistory
           tokens={mockTokens}
           contributions={mockContributions}
           address={mockAddress}

--- a/packages/grant-explorer/src/features/contributors/__tests__/ViewContributionHistory.test.tsx
+++ b/packages/grant-explorer/src/features/contributors/__tests__/ViewContributionHistory.test.tsx
@@ -112,6 +112,8 @@ describe("<ViewContributionHistoryDisplay/>", () => {
 
     expect(screen.getByText("Donation Impact")).toBeInTheDocument();
     expect(screen.getByText("Donation History")).toBeInTheDocument();
+    expect(screen.getByText("Active Rounds")).toBeInTheDocument();
+    expect(screen.getByText("Past Rounds")).toBeInTheDocument();
     expect(
       screen.getByText(mockAddress.slice(0, 6) + "..." + mockAddress.slice(-6))
     ).toBeInTheDocument();

--- a/packages/grant-explorer/src/features/contributors/__tests__/ViewContributionHistory.test.tsx
+++ b/packages/grant-explorer/src/features/contributors/__tests__/ViewContributionHistory.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import { faker } from "@faker-js/faker";
 import {
   ViewContributionHistoryDisplay,
@@ -164,7 +164,9 @@ describe("<ViewContributionHistoryWithoutDonations/>", () => {
       </MemoryRouter>
     );
 
-    expect(screen.getByText("Donation History")).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByText("Donation History")).toBeInTheDocument();
+    });
     expect(
       screen.getByText(mockAddress.slice(0, 6) + "..." + mockAddress.slice(-6))
     ).toBeInTheDocument();

--- a/packages/grant-explorer/tailwind.config.js
+++ b/packages/grant-explorer/tailwind.config.js
@@ -2,10 +2,6 @@ module.exports = {
   content: ["./src/**/*.{js,jsx,ts,tsx}"],
   theme: {
     extend: {
-      screens: {
-        custom_lg: [{ min: "1200px", max: "1499px" }],
-        xl: "1500px",
-      },
       animation: {
         "pulse-scale": "pulse-scale 2s ease-in-out infinite",
       },


### PR DESCRIPTION
<!-- 
Thank you for your pull request! Please review the requirements below 
and ensure your pull request has fulfilled all requirements outlined in the target package.
-->

##### Description

As a DONOR
I want to distinguish my donations to Active Rounds vs. Past Rounds
So that I can easily find my donations

As a donor
I want to see my Donation History page on mobile
So that I can view my donations on my phone

As a DONOR
I want to be able to navigate to and from my profile
so that I can easily check my donation history

##### Refers/Fixes

fixes #1898 
fixes #1928 
fixes #1900 

<!-- If this PR is related to a GitHub issue, please add a link here. -->

##### Testing

<!-- All PRs should be accompanied by tests! If you haven't added tests, please explain here. -->
