### PR TITLE
add a metatag in the index.html page with the git sha of the latest commit in the build

### DIFF
--- a/packages/builder/package.json
+++ b/packages/builder/package.json
@@ -79,7 +79,7 @@
   },
   "scripts": {
     "start": "craco start",
-    "build": "export REACT_APP_GIT_SHA=$(git rev-parse --short HEAD); env REACT_APP_GIT_SHA=${REACT_APP_GIT_SHA:-$CF_PAGES_COMMIT_SHA} craco build",
+    "build": "env REACT_APP_GIT_SHA=$(git rev-parse --short HEAD) craco build",
     "test": "jest --watchAll=false",
     "test:dev": "jest --watch",
     "test:coverage": "jest --watchAll=false --coverage",

--- a/packages/grant-explorer/package.json
+++ b/packages/grant-explorer/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "license": "AGPL-3.0-only",
   "scripts": {
-    "build": "craco build",
+    "build": "env REACT_APP_GIT_SHA=$(git rev-parse --short HEAD) craco build",
     "eject": "react-scripts eject",
     "lint:ci": "pnpm lint:fix --max-warnings=0",
     "lint:fix": "eslint ./src --fix",

--- a/packages/grant-explorer/public/index.html
+++ b/packages/grant-explorer/public/index.html
@@ -5,6 +5,7 @@
     <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
+    <meta name="git-sha" content="%REACT_APP_GIT_SHA%" />
     <meta name="description" content="Create & Manage Rounds" />
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
     <!--

--- a/packages/round-manager/package.json
+++ b/packages/round-manager/package.json
@@ -10,6 +10,7 @@
   "scripts": {
     "start": "craco start",
     "build": "craco build",
+    "build": "env REACT_APP_GIT_SHA=$(git rev-parse --short HEAD) craco build",
     "test": "craco test --watchAll=false --silent",
     "test:dev": "craco test --watchAll=true",
     "test:coverage": "craco test --watchAll=false --silent --coverage",

--- a/packages/round-manager/public/index.html
+++ b/packages/round-manager/public/index.html
@@ -5,6 +5,7 @@
     <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
+    <meta name="git-sha" content="%REACT_APP_GIT_SHA%" />
     <meta name="description" content="Create & Manage Rounds" />
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
     <!--


### PR DESCRIPTION
This PR adds a metatag in the index.html page with the git sha of the latest commit in the build.
This allows us to check the version deployed in each environment for each front-end app.
`Builder` already had it, we simplified it removing the env variable needed for cloudflare pages.