### PR TITLE
chore: split up Apply component and disable default export eslint rule

### DIFF
--- a/packages/builder/.eslintrc.js
+++ b/packages/builder/.eslintrc.js
@@ -24,6 +24,7 @@ module.exports = {
     "react/prop-types": "off",
     "max-len": ["error", { code: 150 }],
     "no-console": "off",
+    "import/prefer-default-export": "off",
     "no-restricted-syntax": [
       "error",
       "ForInStatement",

--- a/packages/builder/src/actions/roundApplication.ts
+++ b/packages/builder/src/actions/roundApplication.ts
@@ -127,6 +127,7 @@ const dispatchAndLogApplicationError = (
   datadogLogs.logger.error(error, {
     roundAddress,
   });
+  debugger;
   dispatch(applicationError(roundAddress, error, step));
 };
 
@@ -233,6 +234,7 @@ export const submitApplication =
 
       deterministicApplication = objectToDeterministicJSON(application as any);
     } catch (error) {
+      console.error(error);
       dispatchAndLogApplicationError(
         dispatch,
         roundAddress,

--- a/packages/builder/src/actions/roundApplication.ts
+++ b/packages/builder/src/actions/roundApplication.ts
@@ -127,7 +127,6 @@ const dispatchAndLogApplicationError = (
   datadogLogs.logger.error(error, {
     roundAddress,
   });
-  debugger;
   dispatch(applicationError(roundAddress, error, step));
 };
 

--- a/packages/builder/src/actions/roundApplication.ts
+++ b/packages/builder/src/actions/roundApplication.ts
@@ -233,7 +233,6 @@ export const submitApplication =
 
       deterministicApplication = objectToDeterministicJSON(application as any);
     } catch (error) {
-      console.error(error);
       dispatchAndLogApplicationError(
         dispatch,
         roundAddress,

--- a/packages/builder/src/components/application/AboutProject.tsx
+++ b/packages/builder/src/components/application/AboutProject.tsx
@@ -1,0 +1,152 @@
+import { useEnsName } from "wagmi";
+import { GlobeAltIcon } from "@heroicons/react/24/solid";
+import { ChainId } from "common";
+import { Metadata, RoundApplicationQuestion } from "../../types";
+import { RoundApplicationAnswers } from "../../types/roundApplication";
+import useValidateCredential from "../../hooks/useValidateCredential";
+import { getPayoutIcon } from "../../utils/wallet";
+import Calendar from "../icons/Calendar";
+import colors from "../../styles/colors";
+import { GithubLogo, TwitterLogo } from "../../assets";
+import GreenVerifiedBadge from "../badges/GreenVerifiedBadge";
+import { DetailSummary } from "./DetailSummary";
+
+export function AboutProject(props: {
+  projectToRender: Metadata;
+  questions: RoundApplicationQuestion[];
+  answers: RoundApplicationAnswers;
+  chainId: ChainId;
+}) {
+  const { projectToRender, answers, questions, chainId } = props;
+
+  const { website, projectTwitter, projectGithub, userGithub, credentials } =
+    projectToRender;
+
+  const { isValid: validTwitterCredential } = useValidateCredential(
+    credentials?.twitter,
+    projectTwitter
+  );
+
+  const { isValid: validGithubCredential } = useValidateCredential(
+    credentials?.github,
+    projectGithub
+  );
+
+  const recipientQuestion = questions.find((item) => item.type === "recipient");
+  const recipient = recipientQuestion
+    ? answers[recipientQuestion.id.toString()].toString()
+    : undefined;
+
+  const { data: ensName } = useEnsName({
+    address: recipient ?? "",
+  });
+
+  return (
+    <div className="grid grid-cols-1 sm:grid-cols-2 pt-2 pb-6">
+      {recipient && (
+        <span className="flex items-center mt-4 gap-1">
+          <div className="w-5 h-5 rounded-full overflow-hidden">
+            <img
+              src={getPayoutIcon(chainId)}
+              alt="circle"
+              className="w-full h-full object-cover"
+            />
+          </div>
+          <DetailSummary
+            text={`${
+              ensName || `${recipient.slice(0, 6)}...${recipient.slice(-4)}`
+            }`}
+            testID="project-recipient"
+            sm
+          />
+        </span>
+      )}
+      {projectToRender.createdAt && (
+        <span className="flex items-center mt-4 gap-2">
+          {/* <CalendarIcon className="h-4 w-4 mr-1 opacity-80" /> */}
+          <Calendar color={colors["secondary-text"]} />
+          <DetailSummary
+            text={`Created: ${new Date(
+              projectToRender.createdAt
+            ).toLocaleDateString("en-US", {
+              year: "numeric",
+              month: "short",
+              day: "numeric",
+            })}`}
+            testID="project-createdAt"
+          />
+        </span>
+      )}
+      {website && (
+        <span className="flex items-center mt-4 gap-1">
+          <GlobeAltIcon className="h-4 w-4 mr-1 opacity-40" />
+          <a
+            href={website}
+            target="_blank"
+            rel="noreferrer"
+            className="text-base font-normal text-black"
+          >
+            <DetailSummary
+              text={`${website}`}
+              testID="project-website"
+              violetcolor
+            />
+          </a>
+        </span>
+      )}
+      {projectTwitter && (
+        <span className="flex items-center mt-4 gap-1">
+          <img src={TwitterLogo} className="h-4" alt="Twitter Logo" />
+          <a
+            href={`https://twitter.com/${projectTwitter}`}
+            target="_blank"
+            rel="noreferrer"
+            className="text-base font-normal text-black"
+          >
+            <DetailSummary
+              text={projectTwitter}
+              testID="project-twitter"
+              violetcolor
+            />
+          </a>
+          {validTwitterCredential && <GreenVerifiedBadge />}
+        </span>
+      )}
+      {userGithub && (
+        <span className="flex items-center mt-4 gap-2">
+          <img src={GithubLogo} className="h-4" alt="GitHub Logo" />
+          <a
+            href={`https://github.com/${userGithub}`}
+            target="_blank"
+            rel="noreferrer"
+            className="text-base font-normal text-black"
+          >
+            <DetailSummary
+              text={`${userGithub}`}
+              testID="user-github"
+              violetcolor
+            />
+          </a>
+          {validGithubCredential && <GreenVerifiedBadge />}
+        </span>
+      )}
+      {projectGithub && (
+        <span className="flex items-center mt-4 gap-1">
+          <img src={GithubLogo} className="h-4" alt="GitHub Logo" />
+          <a
+            href={`https://github.com/${projectGithub}`}
+            target="_blank"
+            rel="noreferrer"
+            className="text-base font-normal text-black"
+          >
+            <DetailSummary
+              text={`${projectGithub}`}
+              testID="project-github"
+              violetcolor
+            />
+          </a>
+        </span>
+      )}
+    </div>
+  );
+}

--- a/packages/builder/src/components/application/DetailSummary.tsx
+++ b/packages/builder/src/components/application/DetailSummary.tsx
@@ -1,0 +1,18 @@
+export function DetailSummary(props: {
+  text: string;
+  testID: string;
+  sm?: boolean;
+  violetcolor?: boolean;
+}) {
+  const { text, testID, sm, violetcolor } = props;
+  return (
+    <p
+      className={`${sm ? "text-sm" : "text-base"} font-normal 
+      ${violetcolor ? "text-gitcoin-violet-400" : "text-black"}`}
+      data-testid={testID}
+    >
+      {" "}
+      {text}{" "}
+    </p>
+  );
+}

--- a/packages/builder/src/components/application/Form.tsx
+++ b/packages/builder/src/components/application/Form.tsx
@@ -3,47 +3,31 @@ import { datadogRum } from "@datadog/browser-rum";
 import { ExclamationCircleIcon } from "@heroicons/react/20/solid";
 import {
   ExclamationTriangleIcon,
-  EyeIcon,
-  GlobeAltIcon,
   InformationCircleIcon,
 } from "@heroicons/react/24/solid";
-import { ChainId, renderToHTML } from "common";
 import { Fragment, useEffect, useState } from "react";
 import { shallowEqual, useDispatch, useSelector } from "react-redux";
 import { Link } from "react-router-dom";
-import { useEnsName, useNetwork } from "wagmi";
+import { useNetwork } from "wagmi";
 import { ValidationError } from "yup";
 import { fetchProjectApplicationInRound } from "../../actions/projects";
 import { resetApplicationError } from "../../actions/roundApplication";
-import {
-  DefaultProjectBanner,
-  DefaultProjectLogo,
-  GithubLogo,
-  TwitterLogo,
-} from "../../assets";
 import useValidateCredential from "../../hooks/useValidateCredential";
 import { RootState } from "../../reducers";
 import { editProjectPathByID } from "../../routes";
-import colors from "../../styles/colors";
 import {
   AddressType,
   ChangeHandlers,
   Metadata,
   ProjectOption,
   Round,
-  RoundApplicationQuestion,
 } from "../../types";
 import {
   RoundApplicationAnswers,
   RoundApplicationMetadata,
 } from "../../types/roundApplication";
 import { getProjectURIComponents } from "../../utils/utils";
-import {
-  getNetworkIcon,
-  getPayoutIcon,
-  networkPrettyName,
-} from "../../utils/wallet";
-import GreenVerifiedBadge from "../badges/GreenVerifiedBadge";
+import { getNetworkIcon, networkPrettyName } from "../../utils/wallet";
 import Button, { ButtonVariants } from "../base/Button";
 import CallbackModal from "../base/CallbackModal";
 import ErrorModal from "../base/ErrorModal";
@@ -61,7 +45,7 @@ import {
   TextInput,
   TextInputAddress,
 } from "../grants/inputs";
-import Calendar from "../icons/Calendar";
+import { FullPreview } from "./FullPreview";
 
 const validation = {
   messages: [""],
@@ -72,344 +56,6 @@ const validation = {
 enum ValidationStatus {
   Invalid,
   Valid,
-}
-
-function ProjectTitle(props: { projectMetadata: Metadata }) {
-  const { projectMetadata } = props;
-  return (
-    <div className="pb-2">
-      <h1 className="text-3xl mt-6 font-thin text-black">
-        {projectMetadata.title}
-      </h1>
-    </div>
-  );
-}
-
-function DetailSummary(props: {
-  text: string;
-  testID: string;
-  sm?: boolean;
-  violetcolor?: boolean;
-}) {
-  const { text, testID, sm, violetcolor } = props;
-  return (
-    <p
-      className={`${sm ? "text-sm" : "text-base"} font-normal 
-      ${violetcolor ? "text-gitcoin-violet-400" : "text-black"}`}
-      data-testid={testID}
-    >
-      {" "}
-      {text}{" "}
-    </p>
-  );
-}
-
-function AboutProject(props: {
-  projectToRender: Metadata;
-  questions: RoundApplicationQuestion[];
-  answers: RoundApplicationAnswers;
-  chainId: ChainId;
-}) {
-  const { projectToRender, answers, questions, chainId } = props;
-
-  const { website, projectTwitter, projectGithub, userGithub, credentials } =
-    projectToRender;
-
-  const { isValid: validTwitterCredential } = useValidateCredential(
-    credentials?.twitter,
-    projectTwitter
-  );
-
-  const { isValid: validGithubCredential } = useValidateCredential(
-    credentials?.github,
-    projectGithub
-  );
-
-  const recipientQuestion = questions.find((item) => item.type === "recipient");
-  const recipient = recipientQuestion
-    ? answers[recipientQuestion.id.toString()].toString()
-    : undefined;
-
-  const { data: ensName } = useEnsName({
-    address: recipient ?? "",
-  });
-
-  return (
-    <div className="grid grid-cols-1 sm:grid-cols-2 pt-2 pb-6">
-      {recipient && (
-        <span className="flex items-center mt-4 gap-1">
-          <div className="w-5 h-5 rounded-full overflow-hidden">
-            <img
-              src={getPayoutIcon(chainId)}
-              alt="circle"
-              className="w-full h-full object-cover"
-            />
-          </div>
-          <DetailSummary
-            text={`${
-              ensName || `${recipient.slice(0, 6)}...${recipient.slice(-4)}`
-            }`}
-            testID="project-recipient"
-            sm
-          />
-        </span>
-      )}
-      {projectToRender.createdAt && (
-        <span className="flex items-center mt-4 gap-2">
-          {/* <CalendarIcon className="h-4 w-4 mr-1 opacity-80" /> */}
-          <Calendar color={colors["secondary-text"]} />
-          <DetailSummary
-            text={`Created: ${new Date(
-              projectToRender.createdAt
-            ).toLocaleDateString("en-US", {
-              year: "numeric",
-              month: "short",
-              day: "numeric",
-            })}`}
-            testID="project-createdAt"
-          />
-        </span>
-      )}
-      {website && (
-        <span className="flex items-center mt-4 gap-1">
-          <GlobeAltIcon className="h-4 w-4 mr-1 opacity-40" />
-          <a
-            href={website}
-            target="_blank"
-            rel="noreferrer"
-            className="text-base font-normal text-black"
-          >
-            <DetailSummary
-              text={`${website}`}
-              testID="project-website"
-              violetcolor
-            />
-          </a>
-        </span>
-      )}
-      {projectTwitter && (
-        <span className="flex items-center mt-4 gap-1">
-          <img src={TwitterLogo} className="h-4" alt="Twitter Logo" />
-          <a
-            href={`https://twitter.com/${projectTwitter}`}
-            target="_blank"
-            rel="noreferrer"
-            className="text-base font-normal text-black"
-          >
-            <DetailSummary
-              text={projectTwitter}
-              testID="project-twitter"
-              violetcolor
-            />
-          </a>
-          {validTwitterCredential && <GreenVerifiedBadge />}
-        </span>
-      )}
-      {userGithub && (
-        <span className="flex items-center mt-4 gap-2">
-          <img src={GithubLogo} className="h-4" alt="GitHub Logo" />
-          <a
-            href={`https://github.com/${userGithub}`}
-            target="_blank"
-            rel="noreferrer"
-            className="text-base font-normal text-black"
-          >
-            <DetailSummary
-              text={`${userGithub}`}
-              testID="user-github"
-              violetcolor
-            />
-          </a>
-          {validGithubCredential && <GreenVerifiedBadge />}
-        </span>
-      )}
-      {projectGithub && (
-        <span className="flex items-center mt-4 gap-1">
-          <img src={GithubLogo} className="h-4" alt="GitHub Logo" />
-          <a
-            href={`https://github.com/${projectGithub}`}
-            target="_blank"
-            rel="noreferrer"
-            className="text-base font-normal text-black"
-          >
-            <DetailSummary
-              text={`${projectGithub}`}
-              testID="project-github"
-              violetcolor
-            />
-          </a>
-        </span>
-      )}
-    </div>
-  );
-}
-
-function FullPreview(props: {
-  project: Metadata;
-  answers: RoundApplicationAnswers;
-  questions: RoundApplicationQuestion[];
-  handleSubmitApplication: Function;
-  preview: boolean;
-  setPreview: Function;
-  disableSubmit: boolean;
-  chainId: ChainId;
-}) {
-  const {
-    project,
-    answers,
-    questions,
-    preview,
-    setPreview,
-    handleSubmitApplication,
-    disableSubmit,
-    chainId,
-  } = props;
-  const ipfsPrefix = `${process.env.REACT_APP_PINATA_GATEWAY!}/ipfs/`;
-
-  useEffect(() => {
-    document.getElementById("root")!.scrollTo(0, 0);
-  }, []);
-
-  return (
-    <>
-      {preview && (
-        <div className="flex flex-row items-center">
-          <span className="icon mr-2">
-            <EyeIcon className="w-6 h-5 inline-block text-violet-500 align-middle" />
-          </span>
-          <span className="text-sm text-gray-500">
-            This is a preview of your public project page on Gitcoin Explorer.
-          </span>
-        </div>
-      )}
-      <div className="relative pt-7">
-        <div>
-          <div>
-            <img
-              className="h-32 w-full object-cover lg:h-80 rounded"
-              src={`${
-                project.bannerImg
-                  ? ipfsPrefix + project.bannerImg
-                  : DefaultProjectBanner
-              }?img-height=320`}
-              alt="Project Banner"
-            />
-          </div>
-          <div className="pl-4 sm:pl-6 lg:pl-8">
-            <div className="-mt-1 sm:-mt-2 sm:flex sm:items-end sm:space-x-5">
-              <div className="flex">
-                <div className="pl-4">
-                  <div className="-mt-6 sm:-mt-6 sm:flex sm:items-end sm:space-x-5">
-                    <div className="flex">
-                      <img
-                        className="h-16 w-16 rounded-full ring-4 ring-white bg-white"
-                        src={
-                          project.logoImg
-                            ? ipfsPrefix + project.logoImg
-                            : DefaultProjectLogo
-                        }
-                        alt="Project Logo"
-                      />
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-
-      <div className="flex flex-col md:flex-row">
-        <div className="grow">
-          <div>
-            <ProjectTitle projectMetadata={project} />
-            <AboutProject
-              projectToRender={project}
-              questions={questions}
-              answers={answers}
-              chainId={chainId}
-            />
-          </div>
-          <div>
-            <h1 className="text-2xl mt-8 font-thin text-black">About</h1>
-            <p
-              // eslint-disable-next-line react/no-danger
-              dangerouslySetInnerHTML={{
-                __html: renderToHTML(
-                  project.description.replace(/\n/g, "\n\n")
-                ),
-              }}
-              className="text-md prose prose-h1:text-lg prose-h2:text-base prose-h3:text-base prose-a:text-blue-600"
-            />
-
-            <div className="mt-4 border-t-2">
-              <h1 className="text-2xl mt-6 font-thin text-black">
-                Additional Details
-              </h1>
-              <div>
-                {questions.map((question: any) => {
-                  const currentAnswer = answers[question.id];
-                  const answerText = Array.isArray(currentAnswer)
-                    ? currentAnswer.join(", ")
-                    : currentAnswer || "";
-
-                  return (
-                    <div>
-                      {!question.hidden && question.type !== "project" && (
-                        <div key={question.id}>
-                          <p className="text-md mt-8 mb-3 font-semibold text-black">
-                            {question.type === "recipient"
-                              ? "Recipient"
-                              : question.title}
-                          </p>
-                          {question.type === "paragraph" ? (
-                            <p
-                              // eslint-disable-next-line react/no-danger
-                              dangerouslySetInnerHTML={{
-                                __html: renderToHTML(
-                                  answerText.toString().replace(/\n/g, "\n\n")
-                                ),
-                              }}
-                              className="text-md prose prose-h1:text-lg prose-h2:text-base prose-h3:text-base prose-a:text-blue-600"
-                            />
-                          ) : (
-                            <p className="text-base text-black">
-                              {answerText.toString().replace(/\n/g, "<br/>")}
-                            </p>
-                          )}
-                        </div>
-                      )}
-                    </div>
-                  );
-                })}
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-      <div className="flex justify-end">
-        <div className="flex justify-end">
-          <Button
-            variant={ButtonVariants.outline}
-            onClick={() => {
-              setPreview(false);
-            }}
-          >
-            Back to Editing
-          </Button>
-          <Button
-            variant={ButtonVariants.primary}
-            onClick={() => {
-              handleSubmitApplication();
-            }}
-            disabled={disableSubmit}
-          >
-            Submit
-          </Button>
-        </div>
-      </div>
-    </>
-  );
 }
 
 export default function Form({
@@ -686,6 +332,9 @@ export default function Form({
 
   const needsProject = schema.questions.find((q) => q.type === "project");
   const now = new Date().getTime() / 1000;
+
+  console.log(now, round.applicationsEndTime);
+  console.log(round.applicationsEndTime > now);
 
   return (
     <>
@@ -1198,7 +847,7 @@ export default function Form({
           onRetry={handleSubmitApplicationRetry}
           title="Round Application Period Closed"
         >
-          {round.applicationsEndTime > now ? (
+          {round.applicationsEndTime < now ? (
             <div className="my-2">
               The application period for this round has closed.
             </div>

--- a/packages/builder/src/components/application/Form.tsx
+++ b/packages/builder/src/components/application/Form.tsx
@@ -333,9 +333,6 @@ export default function Form({
   const needsProject = schema.questions.find((q) => q.type === "project");
   const now = new Date().getTime() / 1000;
 
-  console.log(now, round.applicationsEndTime);
-  console.log(round.applicationsEndTime > now);
-
   return (
     <>
       {preview && selectedProjectMetadata && (

--- a/packages/builder/src/components/application/FullPreview.tsx
+++ b/packages/builder/src/components/application/FullPreview.tsx
@@ -1,0 +1,177 @@
+import { useEffect } from "react";
+import { EyeIcon } from "@heroicons/react/24/solid";
+import { ChainId, renderToHTML } from "common";
+import { Metadata, RoundApplicationQuestion } from "../../types";
+import { RoundApplicationAnswers } from "../../types/roundApplication";
+import { DefaultProjectBanner, DefaultProjectLogo } from "../../assets";
+import Button, { ButtonVariants } from "../base/Button";
+import { AboutProject } from "./AboutProject";
+import { ProjectTitle } from "./ProjectTitle";
+
+export function FullPreview(props: {
+  project: Metadata;
+  answers: RoundApplicationAnswers;
+  questions: RoundApplicationQuestion[];
+  handleSubmitApplication: Function;
+  preview: boolean;
+  setPreview: Function;
+  disableSubmit: boolean;
+  chainId: ChainId;
+}) {
+  const {
+    project,
+    answers,
+    questions,
+    preview,
+    setPreview,
+    handleSubmitApplication,
+    disableSubmit,
+    chainId,
+  } = props;
+  const ipfsPrefix = `${process.env.REACT_APP_PINATA_GATEWAY!}/ipfs/`;
+
+  useEffect(() => {
+    document.getElementById("root")!.scrollTo(0, 0);
+  }, []);
+
+  return (
+    <>
+      {preview && (
+        <div className="flex flex-row items-center">
+          <span className="icon mr-2">
+            <EyeIcon className="w-6 h-5 inline-block text-violet-500 align-middle" />
+          </span>
+          <span className="text-sm text-gray-500">
+            This is a preview of your public project page on Gitcoin Explorer.
+          </span>
+        </div>
+      )}
+      <div className="relative pt-7">
+        <div>
+          <div>
+            <img
+              className="h-32 w-full object-cover lg:h-80 rounded"
+              src={`${
+                project.bannerImg
+                  ? ipfsPrefix + project.bannerImg
+                  : DefaultProjectBanner
+              }?img-height=320`}
+              alt="Project Banner"
+            />
+          </div>
+          <div className="pl-4 sm:pl-6 lg:pl-8">
+            <div className="-mt-1 sm:-mt-2 sm:flex sm:items-end sm:space-x-5">
+              <div className="flex">
+                <div className="pl-4">
+                  <div className="-mt-6 sm:-mt-6 sm:flex sm:items-end sm:space-x-5">
+                    <div className="flex">
+                      <img
+                        className="h-16 w-16 rounded-full ring-4 ring-white bg-white"
+                        src={
+                          project.logoImg
+                            ? ipfsPrefix + project.logoImg
+                            : DefaultProjectLogo
+                        }
+                        alt="Project Logo"
+                      />
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div className="flex flex-col md:flex-row">
+        <div className="grow">
+          <div>
+            <ProjectTitle projectMetadata={project} />
+            <AboutProject
+              projectToRender={project}
+              questions={questions}
+              answers={answers}
+              chainId={chainId}
+            />
+          </div>
+          <div>
+            <h1 className="text-2xl mt-8 font-thin text-black">About</h1>
+            <p
+              // eslint-disable-next-line react/no-danger
+              dangerouslySetInnerHTML={{
+                __html: renderToHTML(
+                  project.description.replace(/\n/g, "\n\n")
+                ),
+              }}
+              className="text-md prose prose-h1:text-lg prose-h2:text-base prose-h3:text-base prose-a:text-blue-600"
+            />
+
+            <div className="mt-4 border-t-2">
+              <h1 className="text-2xl mt-6 font-thin text-black">
+                Additional Details
+              </h1>
+              <div>
+                {questions.map((question: any) => {
+                  const currentAnswer = answers[question.id];
+                  const answerText = Array.isArray(currentAnswer)
+                    ? currentAnswer.join(", ")
+                    : currentAnswer || "";
+
+                  return (
+                    <div>
+                      {!question.hidden && question.type !== "project" && (
+                        <div key={question.id}>
+                          <p className="text-md mt-8 mb-3 font-semibold text-black">
+                            {question.type === "recipient"
+                              ? "Recipient"
+                              : question.title}
+                          </p>
+                          {question.type === "paragraph" ? (
+                            <p
+                              // eslint-disable-next-line react/no-danger
+                              dangerouslySetInnerHTML={{
+                                __html: renderToHTML(
+                                  answerText.toString().replace(/\n/g, "\n\n")
+                                ),
+                              }}
+                              className="text-md prose prose-h1:text-lg prose-h2:text-base prose-h3:text-base prose-a:text-blue-600"
+                            />
+                          ) : (
+                            <p className="text-base text-black">
+                              {answerText.toString().replace(/\n/g, "<br/>")}
+                            </p>
+                          )}
+                        </div>
+                      )}
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div className="flex justify-end">
+        <div className="flex justify-end">
+          <Button
+            variant={ButtonVariants.outline}
+            onClick={() => {
+              setPreview(false);
+            }}
+          >
+            Back to Editing
+          </Button>
+          <Button
+            variant={ButtonVariants.primary}
+            onClick={() => {
+              handleSubmitApplication();
+            }}
+            disabled={disableSubmit}
+          >
+            Submit
+          </Button>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/packages/builder/src/components/application/ProjectTitle.tsx
+++ b/packages/builder/src/components/application/ProjectTitle.tsx
@@ -1,0 +1,12 @@
+import { Metadata } from "../../types";
+
+export function ProjectTitle(props: { projectMetadata: Metadata }) {
+  const { projectMetadata } = props;
+  return (
+    <div className="pb-2">
+      <h1 className="text-3xl mt-6 font-thin text-black">
+        {projectMetadata.title}
+      </h1>
+    </div>
+  );
+}

--- a/packages/builder/src/utils/RoundApplicationBuilder.ts
+++ b/packages/builder/src/utils/RoundApplicationBuilder.ts
@@ -27,7 +27,6 @@ export default class RoundApplicationBuilder {
     this.ram = ram;
     this.roundAddress = roundAddress;
     this.chainName = chainName;
-    debugger;
     const litInit = {
       chain: chainName,
       contract: this.roundAddress,

--- a/packages/builder/src/utils/RoundApplicationBuilder.ts
+++ b/packages/builder/src/utils/RoundApplicationBuilder.ts
@@ -27,7 +27,7 @@ export default class RoundApplicationBuilder {
     this.ram = ram;
     this.roundAddress = roundAddress;
     this.chainName = chainName;
-
+    debugger;
     const litInit = {
       chain: chainName,
       contract: this.roundAddress,

--- a/packages/builder/src/utils/projects.ts
+++ b/packages/builder/src/utils/projects.ts
@@ -4,7 +4,6 @@ import ProjectRegistryABI from "../contracts/abis/ProjectRegistry.json";
 import { getProviderByChainId } from "./utils";
 import { addressesByChainID } from "../contracts/deployments";
 
-// eslint-disable-next-line import/prefer-default-export
 export const fetchProjectOwners = (chainID: ChainId, projectID: string) => {
   const addresses = addressesByChainID(chainID);
   const appProvider = getProviderByChainId(chainID);


### PR DESCRIPTION
- splits out the huge Apply.tsx in builder (1200-line files are not ok 😬)
- disables the eslint rule to prefer default exports on files with single export (prefer named exports to prevent mis-naming imports)
- removes eslint-ignores of the aforementioned rule
- fixes the error for applications not open