### PR TITLE
fix: eth -> ftm token 

### DIFF
--- a/packages/grant-explorer/src/features/round/ViewRoundPage.tsx
+++ b/packages/grant-explorer/src/features/round/ViewRoundPage.tsx
@@ -213,7 +213,7 @@ function AfterRoundStart(props: {
   return (
     <>
       {showCartNotification && renderCartNotification()}
-      <Navbar isBeforeRoundEndDate={props.isBeforeRoundEndDate} />
+      <Navbar />
       {props.isBeforeRoundEndDate && (
         <PassportBanner chainId={chainId} round={round} />
       )}
@@ -500,7 +500,9 @@ function PreRoundPage(props: {
   const matchingFundPayoutTokenName =
     round &&
     payoutTokens.filter(
-      (t) => t.address.toLocaleLowerCase() === round.token.toLocaleLowerCase()
+      (t) =>
+        t.address.toLowerCase() === round.token.toLowerCase() &&
+        t.chainId.toString() === chainId
     )[0]?.name;
 
   return (

--- a/packages/round-manager/src/features/round/ViewRoundSettings.tsx
+++ b/packages/round-manager/src/features/round/ViewRoundSettings.tsx
@@ -1666,7 +1666,8 @@ function Funding(props: {
     editedRound &&
     payoutTokens.filter(
       (t) =>
-        t.address.toLocaleLowerCase() == editedRound.token.toLocaleLowerCase()
+        t.address.toLowerCase() == editedRound.token.toLowerCase() &&
+        t.chainId == editedRound.chainId
     )[0];
 
   const matchingFunds =

--- a/packages/round-manager/src/features/round/ViewRoundStats.tsx
+++ b/packages/round-manager/src/features/round/ViewRoundStats.tsx
@@ -9,10 +9,11 @@ import {
 } from "../../hooks";
 import { getUTCDate } from "common";
 import { payoutTokens } from "../api/utils";
+import { useChainId } from "wagmi";
 
 export default function ViewRoundStats() {
   const { id } = useParams();
-
+  const chainId = useChainId();
   const roundId = utils.getAddress(id?.toLowerCase() ?? "");
 
   const { data: round } = useRound(roundId);
@@ -26,7 +27,9 @@ export default function ViewRoundStats() {
   const matchToken =
     round &&
     payoutTokens.find(
-      (t) => t.address.toLowerCase() == round.token.toLowerCase()
+      (t) =>
+        t.address.toLowerCase() == round.token.toLowerCase() &&
+        t.chainId === chainId
     );
 
   return (


### PR DESCRIPTION
fixes #2261 

Fixes FTM matching funds being displayed as ETH in various places in explorer and manager, by checking for chainId as well as the token name.