### PR TITLE
fix: rename arbitrum one to arbitrum for lit js  sdk

### DIFF
--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -24,7 +24,7 @@ jobs:
 
     - uses: actions/setup-node@v3
       with:
-        node-version: '18'
+        node-version: '16'
         cache: 'pnpm'
 
     - name: Install Dependencies

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "// builder script": "====== packages/builder specific ======",
     "b-start": "pnpm --filter builder run start",
     "b-lint": "turbo run lint:ci --filter=builder",
-    "b-test": "turbo run test --filter=builder",
+    "b-test": "pnpm test --filter=builder",
     "b-typecheck": "turbo run typecheck --filter=builder"
   },
   "devDependencies": {

--- a/packages/grant-explorer/src/features/api/__tests__/utils.test.tsx
+++ b/packages/grant-explorer/src/features/api/__tests__/utils.test.tsx
@@ -107,7 +107,7 @@ describe("fetchFromIPFS", () => {
     const res = await fetchFromIPFS(cid);
 
     expect(fetchMock).toHaveBeenCalledWith(
-      `https://${process.env.REACT_APP_PINATA_GATEWAY}/ipfs/${cid}`
+      `${process.env.REACT_APP_PINATA_GATEWAY}/ipfs/${cid}`
     );
     expect(res).toEqual({ name: "My First Metadata" });
   });
@@ -122,7 +122,7 @@ describe("fetchFromIPFS", () => {
     await expect(fetchFromIPFS(cid)).rejects.toHaveProperty("status", 404);
 
     expect(fetchMock).toHaveBeenCalledWith(
-      `https://${process.env.REACT_APP_PINATA_GATEWAY}/ipfs/${cid}`
+      `${process.env.REACT_APP_PINATA_GATEWAY}/ipfs/${cid}`
     );
   });
 });

--- a/packages/grant-explorer/src/features/api/utils.ts
+++ b/packages/grant-explorer/src/features/api/utils.ts
@@ -427,15 +427,15 @@ export const graphql_fetch = async (
  * @param cid - the unique content identifier that points to the data
  */
 export const fetchFromIPFS = (cid: string) => {
-  return fetch(
-    `https://${process.env.REACT_APP_PINATA_GATEWAY}/ipfs/${cid}`
-  ).then((resp) => {
-    if (resp.ok) {
-      return resp.json();
-    }
+  return fetch(`${process.env.REACT_APP_PINATA_GATEWAY}/ipfs/${cid}`).then(
+    (resp) => {
+      if (resp.ok) {
+        return resp.json();
+      }
 
-    return Promise.reject(resp);
-  });
+      return Promise.reject(resp);
+    }
+  );
 };
 
 /**

--- a/packages/round-manager/src/features/api/__tests__/utils.test.ts
+++ b/packages/round-manager/src/features/api/__tests__/utils.test.ts
@@ -28,7 +28,7 @@ describe("fetchFromIPFS", () => {
     const res = await fetchFromIPFS(cid);
 
     expect(fetchMock).toHaveBeenCalledWith(
-      `https://${process.env.REACT_APP_PINATA_GATEWAY}/ipfs/${cid}`
+      `${process.env.REACT_APP_PINATA_GATEWAY}/ipfs/${cid}`
     );
     expect(res).toEqual({ name: "My First Metadata" });
   });
@@ -43,7 +43,7 @@ describe("fetchFromIPFS", () => {
     await expect(fetchFromIPFS(cid)).rejects.toHaveProperty("status", 404);
 
     expect(fetchMock).toHaveBeenCalledWith(
-      `https://${process.env.REACT_APP_PINATA_GATEWAY}/ipfs/${cid}`
+      `${process.env.REACT_APP_PINATA_GATEWAY}/ipfs/${cid}`
     );
   });
 });
@@ -251,7 +251,7 @@ describe("checkGrantApplicationStatus", () => {
     const res = await checkGrantApplicationStatus("1", metadataPointer);
 
     expect(fetchMock).toHaveBeenCalledWith(
-      `https://${process.env.REACT_APP_PINATA_GATEWAY}/ipfs/${metadataPointer.pointer}`
+      `${process.env.REACT_APP_PINATA_GATEWAY}/ipfs/${metadataPointer.pointer}`
     );
     expect(res).toEqual("FRAUD");
   });

--- a/packages/round-manager/src/features/api/utils.ts
+++ b/packages/round-manager/src/features/api/utils.ts
@@ -443,15 +443,15 @@ export const getPayoutTokenOptions = (chainId: ChainId): PayoutToken[] => {
  * @param cid - the unique content identifier that points to the data
  */
 export const fetchFromIPFS = (cid: string) => {
-  return fetch(
-    `https://${process.env.REACT_APP_PINATA_GATEWAY}/ipfs/${cid}`
-  ).then((resp) => {
-    if (resp.ok) {
-      return resp.json();
-    }
+  return fetch(`${process.env.REACT_APP_PINATA_GATEWAY}/ipfs/${cid}`).then(
+    (resp) => {
+      if (resp.ok) {
+        return resp.json();
+      }
 
-    return Promise.reject(resp);
-  });
+      return Promise.reject(resp);
+    }
+  );
 };
 
 /**

--- a/packages/round-manager/src/features/round/ViewApplicationPage.tsx
+++ b/packages/round-manager/src/features/round/ViewApplicationPage.tsx
@@ -261,12 +261,18 @@ export default function ViewApplicationPage() {
 
               const response = await fetch(base64EncryptedString);
               const encryptedString: Blob = await response.blob();
+              let fixedChainName = chain.name;
+              switch (fixedChainName.toLowerCase()) {
+                case "pgn":
+                  fixedChainName = "publicGoodsNetwork";
+                  break;
 
+                case "arbitrum one":
+                  fixedChainName = "arbitrum";
+                  break;
+              }
               const lit = new Lit({
-                chain:
-                  chain.name.toLowerCase() === "pgn"
-                    ? "publicGoodsNetwork"
-                    : chain.name.toLowerCase(),
+                chain: fixedChainName.toLowerCase(),
                 contract: utils.getAddress(roundId),
               });
 


### PR DESCRIPTION
- fixes #2332 
- fixes bug with pinata URL being double-prefixed with https on vercel

superseded by https://github.com/gitcoinco/grants-stack/pull/2339