### PR TITLE
feat: discover scroll anchor

### DIFF
--- a/packages/grant-explorer/src/features/categories/CategoryCard.tsx
+++ b/packages/grant-explorer/src/features/categories/CategoryCard.tsx
@@ -1,3 +1,4 @@
+import { Link } from "react-router-dom";
 import { BasicCard, CardContent, CardHeader } from "../common/styles";
 import { CategoryBanner } from "../discovery/CardBanner";
 import { Category } from "./hooks/useCategories";
@@ -6,6 +7,12 @@ type CategoryCardProps = {
   category: Category;
   isLoading?: boolean;
 };
+
+function scrollToDiscoveryAnchor() {
+  document
+    .getElementById("discovery-scroll-anchor")
+    ?.scrollIntoView({ block: "nearest" });
+}
 
 const CategoryCard = ({ category, isLoading }: CategoryCardProps) => {
   if (isLoading) {
@@ -18,10 +25,12 @@ const CategoryCard = ({ category, isLoading }: CategoryCardProps) => {
 
   return (
     <BasicCard className="w-full">
-      <a
-        target="_blank"
-        href={`/#/projects?categoryId=${id}`}
+      <Link
+        to={`/projects?categoryId=${id}`}
         data-track-event="home-category-card"
+        onClick={() => {
+          scrollToDiscoveryAnchor();
+        }}
       >
         <CardHeader>
           <CategoryBanner projectIds={projectIds} />
@@ -29,7 +38,7 @@ const CategoryCard = ({ category, isLoading }: CategoryCardProps) => {
         <CardContent>
           <div className="font-medium truncate text-xl">{name}</div>
         </CardContent>
-      </a>
+      </Link>
     </BasicCard>
   );
 };

--- a/packages/grant-explorer/src/features/discovery/LandingHero.tsx
+++ b/packages/grant-explorer/src/features/discovery/LandingHero.tsx
@@ -5,10 +5,11 @@ import LandingTabs from "./LandingTabs";
 export default function LandingHero() {
   return (
     <div>
-      <div className="flex items-center gap-12 lg:gap-24 mb-16">
+      <div className="flex items-center gap-12 lg:gap-24">
         <ByTheNumbers />
         <Logo />
       </div>
+      <div id="discovery-scroll-anchor" className="mb-16 " />
       <LandingTabs />
     </div>
   );


### PR DESCRIPTION
this adds a scroll anchor that can be used when navigating between projects & rounds in the landing page, the scroll will not change unnecessarily, it will scroll you up if you are far down from the tabs

if we used normal URI paths for routing we could use the fragment to anchor to an element, but we're using the fragment for routing

not sure if there's a cleaner way to do this, but it works

## PR checklist

For every PR, make sure that these statements are true:
- [ ] Includes only changes relevant to the original ticket. Significant refactoring needs to be separated.
- [ ] Doesn't contain type casts and non-null assertions.
- [ ] Doesn't add `@ts-ignore`.
- [ ] Doesn't disable lints.
- [ ] Doesn't use `useState` just for computation - use plain variables instead.
- [ ] Splits components into pure components that don't depend on external state or hooks.
- [ ] Avoid embedding components within other components
- [ ] Doesn't propagate optional values without good reason, doesn't mark property values as optional if that doesn't represent reality.
- [ ] Doesn't duplicate existing code.
- [ ] Parses out-of-domain data - this includes user input, API respones, on-chain data etc.
- [ ] Doesn't contain commented out code.
- [ ] Doesn't contain skipped or empty tests.
- [ ] If this PR adds/updates any feature, it adds/updates its test script

Subjective - at the discretion of the reviewers
- Does things as simply as possible, but not simpler.
- Doesn't reinvent the wheel or create premature abstractions.

##### Description

<!-- Describe your changes here. -->

##### Refers/Fixes

fixes #issuenumber
