### PR TITLE
Remove one of the ACS rounds from explorer homepage

### DIFF
--- a/packages/grant-explorer/src/features/api/rounds.ts
+++ b/packages/grant-explorer/src/features/api/rounds.ts
@@ -38,6 +38,7 @@ const invalidRounds = [
   "0x1427a0e71a222b0229a910dc72da01f8f04c7441",
   "0xc25994667632d55a8e3dae88737e36f496600434",
   "0x21d264139d66dd281dcb0177bbdca5ceeb71ad69",
+  "0x822742805c0596e883aba99ba2f3117e8c49b94a",
 ].map((a) => a.toLowerCase());
 
 export type RoundOverview = {


### PR DESCRIPTION
<!-- Thank you for your pull request! Before marking it as "Ready for review",
please ensure that all items of checklist are satisfied and that CI checks are
passing.  -->

Fixes: #2724 

Remove one of the ACS rounds from explorer homepage

<!-- Describe your changes here. -->

## Checklist

This PR:

- [x] Includes only changes relevant to the original ticket. Significant refactoring needs to be separated.
- [x] Doesn't disable eslint rules.
- [x] Doesn't work around the type checker (including but not limited to: type casts, non-null assertions, `@ts-ignore`, unjustified optional values).
- [x] Doesn't contain commented out code.
- [x] If adding/updating a feature, it adds/updates its test script on Notion.
