### PR TITLE
feat: clear projects from expired rounds from cart

### DIFF
--- a/packages/grant-explorer/src/features/round/ViewCartPage/SummaryContainer.tsx
+++ b/packages/grant-explorer/src/features/round/ViewCartPage/SummaryContainer.tsx
@@ -35,8 +35,12 @@ export function SummaryContainer() {
   const { data: walletClient } = useWalletClient();
   const navigate = useNavigate();
   const { address, isConnected } = useAccount();
-  const { projects, getVotingTokenForChain, chainToVotingToken } =
-    useCartStorage();
+  const {
+    projects,
+    getVotingTokenForChain,
+    chainToVotingToken,
+    remove: removeProjectFromCart,
+  } = useCartStorage();
   const { checkout, voteStatus, chainsToCheckout } = useCheckoutStore();
   const dataLayer = useDataLayer();
 
@@ -127,6 +131,25 @@ export function SummaryContainer() {
       })
     );
   });
+
+  /** useEffect to clear projects from expired rounds (no longer accepting donations) */
+  useEffect(() => {
+    if (!rounds) {
+      return;
+    }
+    /*get rounds that have expired */
+    const expiredRounds = rounds
+      .filter((round) => round.roundEndTime.getTime() < Date.now())
+      .map((round) => round.id)
+      .filter((id): id is string => id !== undefined);
+
+    const expiredProjects = projects.filter((project) =>
+      expiredRounds.includes(project.roundId)
+    );
+    expiredProjects.forEach((project) => {
+      removeProjectFromCart(project.grantApplicationId);
+    });
+  }, [projects, removeProjectFromCart, rounds]);
 
   const [clickedSubmit, setClickedSubmit] = useState(false);
 

--- a/packages/grant-explorer/src/features/round/ViewCartPage/SummaryContainer.tsx
+++ b/packages/grant-explorer/src/features/round/ViewCartPage/SummaryContainer.tsx
@@ -30,6 +30,7 @@ import { MatchingEstimateTooltip } from "../../common/MatchingEstimateTooltip";
 import { parseChainId } from "common/src/chains";
 import { useDataLayer } from "data-layer";
 import { fetchBalance } from "@wagmi/core";
+import { isPresent } from "ts-is-present";
 
 export function SummaryContainer() {
   const { data: walletClient } = useWalletClient();
@@ -141,7 +142,7 @@ export function SummaryContainer() {
     const expiredRounds = rounds
       .filter((round) => round.roundEndTime.getTime() < Date.now())
       .map((round) => round.id)
-      .filter((id): id is string => id !== undefined);
+      .filter(isPresent);
 
     const expiredProjects = projects.filter((project) =>
       expiredRounds.includes(project.roundId)


### PR DESCRIPTION

Fixes: #2702

## Description

adds a useEffect that clears expired rounds (their projects) from cart on checkout page. this method incurs no additional network requests.

## Checklist

This PR:

- [x] Includes only changes relevant to the original ticket. Significant refactoring needs to be separated.
- [x] Doesn't disable eslint rules.
- [x] Doesn't work around the type checker (including but not limited to: type casts, non-null assertions, `@ts-ignore`, unjustified optional values).
- [x] Doesn't contain commented out code.
- [x] If adding/updating a feature, it adds/updates its test script on Notion.
