### PR TITLE
fix: only index from projectregistry contract creation block on polygon pos

### DIFF
--- a/packages/builder/src/actions/projects.ts
+++ b/packages/builder/src/actions/projects.ts
@@ -173,7 +173,7 @@ const fetchProjectCreatedUpdatedEvents = async (
   const createdEventSig = ethers.utils.id("ProjectCreated(uint256,address)");
   const createdFilter = {
     address: addresses.projectRegistry,
-    fromBlock: "0x00",
+    fromBlock: chainID === ChainId.POLYGON ? "0x2D01F56" : "0x00",
     toBlock: "latest",
     topics: [createdEventSig, null, ethers.utils.hexZeroPad(account, 32)],
   };
@@ -224,7 +224,7 @@ const fetchProjectCreatedUpdatedEvents = async (
   );
   const updatedFilter = {
     address: addresses.projectRegistry,
-    fromBlock: "0x00",
+    fromBlock: chainID === ChainId.POLYGON ? "0x2D01F56" : "0x00",
     toBlock: "latest",
     topics: [updatedEventSig, hexIDs],
   };


### PR DESCRIPTION
Fixes: #2746

## Description

this constrains the project created and updates `getLogs` call on Polygon PoS to since the ProjectRegistry contract was created. This gives us ample time to move the fetching to the data layer (indexer) before we hit the 5mil block range limit for `getLogs` again.

## Checklist

This PR:

- [x] Includes only changes relevant to the original ticket. Significant refactoring needs to be separated.
- [x] Doesn't disable eslint rules.
- [x] Doesn't work around the type checker (including but not limited to: type casts, non-null assertions, `@ts-ignore`, unjustified optional values).
- [x] Doesn't contain commented out code.
- [x] If adding/updating a feature, it adds/updates its test script on Notion.
