### PR TITLE
feat: add block explorer

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,3 +54,17 @@ services:
       - DEV_CHAIN_HOST=localchain-2
       - DEV_CHAIN_ID=313372
     restart: "no"
+
+  explorer-1:
+    image: otterscan/otterscan
+    environment:
+      - ERIGON_URL=http://127.0.0.1:3005
+    ports:
+      - '127.0.0.1:13005:80'
+      
+  explorer-2:
+    image: otterscan/otterscan
+    environment:
+      - ERIGON_URL=http://127.0.0.1:3007
+    ports:
+      - '127.0.0.1:13007:80'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,15 +18,14 @@ services:
       - '127.0.0.1:3003:8000'
 
   localchain-1:
-    image: ghcr.io/gitcoinco/allo-contracts-v1:main
+    image: ghcr.io/foundry-rs/foundry:latest
+    entrypoint: [ "anvil", "--host", "0.0.0.0", "--chain-id", "313371" ]  
     ports:
       - '127.0.0.1:3005:8545'
-    environment:
-      - DEV_CHAIN_ID=313371
 
   # initializes localchain deploying contracts and populates with test data
   dev-setup-1:
-    image: ghcr.io/gitcoinco/allo-contracts-v1:main
+    image: ghcr.io/gitcoinco/allo-contracts-v1:updates
     depends_on:
       - pinata
       - localchain-1
@@ -36,18 +35,16 @@ services:
       - DEV_CHAIN_HOST=localchain-1
       - DEV_CHAIN_ID=313371
     restart: "no"
-    entrypoint: [ "bash", "-c", "sleep 2 && corepack enable && exec ./docker/deploy-contracts.sh"]
 
   localchain-2:
-    image: ghcr.io/gitcoinco/allo-contracts-v1:pr-1
+    image: ghcr.io/foundry-rs/foundry:latest
+    entrypoint: [ "anvil", "--host", "0.0.0.0", "--chain-id", "313372" ]  
     ports:
       - '127.0.0.1:3007:8545'
-    environment:
-      - DEV_CHAIN_ID=313372
 
   # initializes localchain deploying contracts and populates with test data
   dev-setup-2:
-    image: ghcr.io/gitcoinco/allo-contracts-v1:pr-1
+    image: ghcr.io/gitcoinco/allo-contracts-v1:updates
     depends_on:
       - pinata
       - localchain-2
@@ -57,4 +54,3 @@ services:
       - DEV_CHAIN_HOST=localchain-2
       - DEV_CHAIN_ID=313372
     restart: "no"
-    entrypoint: [ "bash", "-c", "sleep 2 && corepack enable && exec ./docker/deploy-contracts.sh"]


### PR DESCRIPTION
## Description

- split anvil / allo-deployer containers
- add block explorer (otterscan) on ports 13005 and 13007

Note 1: depends on https://github.com/gitcoinco/grants-stack-allo-contracts-v1/pull/3
Note 2: [this populate script](https://github.com/gitcoinco/grants-stack-allo-contracts-v1/blob/main/scripts/dev/populate/projects.ts) fails [here](https://github.com/gitcoinco/grants-stack-allo-contracts-v1/blob/c522ab1c9c9984a0b2645d6383211bfae5ce0ac4/scripts/dev/populate/projects.ts#L29) due to an error from pina, apparently `fetch` isn't providing all the required headers when uploading a file. Might be related to the version bump in node which comes with a different `fetch` client. Needs to be solved before this can be merged, hence leaving as draft.

## Checklist

This PR:

- [ ] Includes only changes relevant to the original ticket. Significant refactoring needs to be separated.
- [ ] Doesn't disable eslint rules.
- [ ] Doesn't work around the type checker (including but not limited to: type casts, non-null assertions, `@ts-ignore`, unjustified optional values).
- [ ] Doesn't contain commented out code.
- [ ] If adding/updating a feature, it adds/updates its test script on Notion.
