### PR TITLE
fix: fonts and styles in passport banner and navbarˆ

### DIFF
--- a/packages/grant-explorer/src/features/common/Navbar.tsx
+++ b/packages/grant-explorer/src/features/common/Navbar.tsx
@@ -40,7 +40,7 @@ export default function Navbar(props: NavbarProps) {
 
   return (
     <nav
-      className={`bg-white/5 backdrop-blur-md fixed w-full z-20 shadow-[0_4px_24px_0px_rgba(0,0,0,0.08)] ${props.customBackground}`}
+      className={`blurred fixed w-full z-20 shadow-[0_4px_24px_0px_rgba(0,0,0,0.08)] ${props.customBackground}`}
     >
       <div className="mx-auto px-4 sm:px-4">
         <div className="flex justify-between h-16">

--- a/packages/grant-explorer/src/features/common/PassportWidget.tsx
+++ b/packages/grant-explorer/src/features/common/PassportWidget.tsx
@@ -66,9 +66,9 @@ export function PassportWidget() {
           direction={isOpen ? "up" : "down"}
         />
         <div
-          className={`backdrop-blur-sm cursor-auto absolute mt-1 top-12 border-2
+          className={`backdrop-blur-[2px] cursor-auto absolute mt-1 top-12 border-2
            z-10 ml-[-75px] font-modern-era-medium md:right-0
-            md:ml-0 md:mr-[-20px] w-96 bg-grey-150 md:bg-opacity-80 py-4 px-6
+            md:ml-0 md:mr-[-20px] w-96 bg-white md:bg-white/90 py-4 px-6
              rounded-3xl shadow-lg ${isOpen ? "block" : "hidden"}`}
         >
           <div className="flex flex-col gap-4 mt-1">

--- a/packages/grant-explorer/src/index.css
+++ b/packages/grant-explorer/src/index.css
@@ -2,23 +2,23 @@
 @import url('https://fonts.googleapis.com/css2?family=DM+Mono:wght@400;500&display=swap');
 
 @font-face {
-  font-family: "Modern Era"; 
-  font-weight: 400;
-  src: local("ModernEraRegular"),
-  url("../public/modern-era-regular.otf") format('opentype');
+    font-family: "Modern Era Regular";
+    font-weight: 400;
+    src: local("ModernEraRegular"),
+    url("../public/modern-era-regular.otf") format('opentype');
 }
 
 @font-face {
-  font-family: "Modern Era"; 
-  font-weight: 500;
-  src: local("ModernEraMedium"),
-  url("../public/modern-era-medium.otf") format('opentype');
+    font-family: "Modern Era Medium";
+    font-weight: 500;
+    src: local("ModernEraMedium"),
+    url("../public/modern-era-medium.otf") format('opentype');
 }
 
 @font-face {
-  font-family: "Modern Era"; 
-  font-weight: 600;
-  src: local("ModernEraBold"),
+    font-family: "Modern Era";
+    font-weight: 600;
+    src: local("ModernEraBold"),
     url("../public/modern-era-bold.otf") format('opentype');
 }
 
@@ -29,54 +29,65 @@
 @tailwind utilities;
 
 .font-dm-mono {
-  font-family: 'DM Mono', monospace;
+    font-family: 'DM Mono', monospace;
 }
 
 .font-modern-era-medium {
-  font-family: 'ModernEraMedium', serif;
+    font-family: 'Modern Era Medium', serif;
 }
+
 .font-modern-era-regular {
-  font-family: 'ModernEraRegular', serif;
+    font-family: 'Modern Era Regular', serif;
+}
+
+.blurred::before {
+    content: '';
+    position: absolute;
+    width: 100%;
+    height: 100%;
+    backdrop-filter: blur(22px);
+    z-index: -1;
+    background-color: rgba(255 255 255 / 3%);
 }
 
 @layer base {
-  html {
-    @apply text-grey-500;
-  }
-
-  h1 {
-    @apply text-7xl;
-  }
-
-  h2 {
-    @apply text-5xl;
-  }
-
-  h3 {
-    @apply text-3xl;
-  }
-
-  h4 {
-    @apply text-2xl;
-  }
-
-  h5 {
-    @apply text-base;
-  }
-
-  h6 {
-    @apply text-sm;
-  }
-
-  p {
-    @apply text-base;
-  }
-
-  .quick-view-summary {
-    margin-right: 0rem;
-
-    @media (max-width: 768px) {
-      margin-right: -4rem;
+    html {
+        @apply text-grey-500;
     }
-  }
+
+    h1 {
+        @apply text-7xl;
+    }
+
+    h2 {
+        @apply text-5xl;
+    }
+
+    h3 {
+        @apply text-3xl;
+    }
+
+    h4 {
+        @apply text-2xl;
+    }
+
+    h5 {
+        @apply text-base;
+    }
+
+    h6 {
+        @apply text-sm;
+    }
+
+    p {
+        @apply text-base;
+    }
+
+    .quick-view-summary {
+        margin-right: 0rem;
+
+        @media (max-width: 768px) {
+            margin-right: -4rem;
+        }
+    }
 }


### PR DESCRIPTION
Fixes: #2609 

## Description

- Fixes the fonts and background blur and colour of the passport dialog
- aligns the navbar bg color and blur to figma

## Checklist

This PR:

- [x] Includes only changes relevant to the original ticket. Significant refactoring needs to be separated.
- [x] Doesn't disable eslint rules.
- [x] Doesn't work around the type checker (including but not limited to: type casts, non-null assertions, `@ts-ignore`, unjustified optional values).
- [x] Doesn't contain commented out code.
- [x] If adding/updating a feature, it adds/updates its test script on Notion.
