### PR TITLE
fix: allow jpeg files in image upload dialog in builderˆ

### DIFF
--- a/packages/builder/src/components/base/ImageInput.tsx
+++ b/packages/builder/src/components/base/ImageInput.tsx
@@ -153,7 +153,7 @@ export default function ImageInput({
             className="hidden"
             type="file"
             name="file"
-            accept=".png,.jpg"
+            accept=".png,.jpg,.jpeg"
           />
           {fileInput && (
             <button


### PR DESCRIPTION
Fixes: #2584 

## Description

fixes the image upload dialog in builder not accepting jpegs

## Checklist

This PR:

- [x] Includes only changes relevant to the original ticket. Significant refactoring needs to be separated.
- [x] Doesn't disable eslint rules.
- [x] Doesn't work around the type checker (including but not limited to: type casts, non-null assertions, `@ts-ignore`, unjustified optional values).
- [x] Doesn't contain commented out code.
- [x] If adding/updating a feature, it adds/updates its test script on Notion.