### PR TITLE
fix: default to mainnet if chain id is not supported

### DIFF
--- a/packages/builder/src/utils/AlloWrapper.tsx
+++ b/packages/builder/src/utils/AlloWrapper.tsx
@@ -3,6 +3,7 @@ import {
   AlloProvider,
   AlloV1,
   AlloV2,
+  ChainId,
   createEthersTransactionSender,
   createPinataIpfsUploader,
   createWaitForIndexerSyncTo,
@@ -24,13 +25,16 @@ function AlloWrapper({ children }: { children: JSX.Element | JSX.Element[] }) {
     if (!web3Provider || !signer || !chainID) {
       setBackend(null);
     } else {
-      const addresses = addressesByChainID(chainID);
+      const addresses = addressesByChainID(chainID) ?? addressesByChainID(1);
+
+      const chainIdSupported = Object.values(ChainId).includes(chainID);
+
       const config = getConfig();
       let alloBackend: Allo;
 
       if (config.allo.version === "allo-v2") {
         alloBackend = new AlloV2({
-          chainId: chainID,
+          chainId: chainIdSupported ? chainID : 1,
           transactionSender: createEthersTransactionSender(
             signer,
             web3Provider
@@ -48,7 +52,7 @@ function AlloWrapper({ children }: { children: JSX.Element | JSX.Element[] }) {
         setBackend(alloBackend);
       } else {
         alloBackend = new AlloV1({
-          chainId: chainID,
+          chainId: chainIdSupported ? chainID : 1,
           transactionSender: createEthersTransactionSender(
             signer,
             web3Provider


### PR DESCRIPTION
Fixes: #2906 

## Description

new behaviour in builder: if the current chain id is not supported, we default to mainnet and we automatically show the wrong chain modal from rainbowkit.

## Checklist

This PR:

- [x] Includes only changes relevant to the original ticket. Significant refactoring needs to be separated.
- [x] Doesn't disable eslint rules.
- [x] Doesn't work around the type checker (including but not limited to: type casts, non-null assertions, `@ts-ignore`, unjustified optional values).
- [x] Doesn't contain commented out code.
- [x] If adding/updating a feature, it adds/updates its test script on Notion.
