### PR TITLE
remove hardcoded strategy name from application.round

### DIFF
--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -307,9 +307,16 @@ export async function getTokenPrice(tokenId: string) {
   return data[0].value;
 }
 
-export const ROUND_PAYOUT_MERKLE = "MERKLE";
-export const ROUND_PAYOUT_DIRECT = "DIRECT";
-export type RoundPayoutType = "MERKLE" | "DIRECT";
+//FIXME: remove old types
+export const ROUND_PAYOUT_MERKLE_OLD = "MERKLE";
+export const ROUND_PAYOUT_DIRECT_OLD = "DIRECT";
+export const ROUND_PAYOUT_MERKLE = "allov1.QF";
+export const ROUND_PAYOUT_DIRECT = "allov1.Direct";
+export type RoundPayoutType =
+  | "MERKLE"
+  | "DIRECT"
+  | "allov1.Direct"
+  | "allov1.QF";
 export type RoundVisibilityType = "public" | "private";
 
 export type { Allo, AlloError, AlloOperation } from "./allo/allo";

--- a/packages/data-layer/src/data.types.ts
+++ b/packages/data-layer/src/data.types.ts
@@ -436,6 +436,7 @@ export type Application = {
   totalDonationsCount: string;
   uniqueDonorsCount: number;
   round: {
+    strategyName: RoundPayoutType;
     donationsStartTime: string;
     donationsEndTime: string;
     applicationsStartTime: string;

--- a/packages/data-layer/src/data.types.ts
+++ b/packages/data-layer/src/data.types.ts
@@ -2,7 +2,11 @@ import { VerifiableCredential } from "@gitcoinco/passport-sdk-types";
 import { RoundApplicationMetadata } from "./roundApplication.types";
 // TODO `RoundPayoutType` and `RoundVisibilityType` are duplicated from `common` to
 // avoid further spaghetti dependencies. They should probably be relocated here.
-export type RoundPayoutType = "MERKLE" | "DIRECT";
+export type RoundPayoutType =
+  | "MERKLE"
+  | "DIRECT"
+  | "allov1.Direct"
+  | "allov1.QF";
 export type RoundVisibilityType = "public" | "private";
 
 export type ApplicationStatus =

--- a/packages/data-layer/src/queries.ts
+++ b/packages/data-layer/src/queries.ts
@@ -173,6 +173,7 @@ export const getApplication = gql`
       totalAmountDonatedInUsd
       uniqueDonorsCount
       round {
+        strategyName
         donationsStartTime
         donationsEndTime
         applicationsStartTime

--- a/packages/grant-explorer/src/features/api/utils.ts
+++ b/packages/grant-explorer/src/features/api/utils.ts
@@ -801,14 +801,11 @@ export const getRoundType = (payoutStrategyName: RoundPayoutType) => {
     case ROUND_PAYOUT_MERKLE_OLD:
     case ROUND_PAYOUT_MERKLE:
       return "Quadratic Funding";
-      break;
     case ROUND_PAYOUT_DIRECT_OLD:
     case ROUND_PAYOUT_DIRECT:
       return "Direct Grants";
-      break;
     default:
       return payoutStrategyName;
-      break;
   }
 };
 

--- a/packages/grant-explorer/src/features/api/utils.ts
+++ b/packages/grant-explorer/src/features/api/utils.ts
@@ -3,6 +3,8 @@ import { CartProject, IPFSObject, Round, VotingToken } from "./types";
 import {
   ChainId,
   graphQlEndpoints,
+  ROUND_PAYOUT_DIRECT_OLD,
+  ROUND_PAYOUT_MERKLE_OLD,
   ROUND_PAYOUT_DIRECT,
   ROUND_PAYOUT_MERKLE,
   RoundPayoutType,
@@ -788,15 +790,19 @@ export function getChainIds(): number[] {
 }
 
 export const isDirectRound = (round: Round) =>
+  round.payoutStrategy.strategyName === ROUND_PAYOUT_DIRECT_OLD ||
   round.payoutStrategy.strategyName === ROUND_PAYOUT_DIRECT;
+
 export const isInfiniteDate = (roundTime: Date) =>
   roundTime.toString() === "Invalid Date";
 
 export const getRoundType = (payoutStrategyName: RoundPayoutType) => {
   switch (payoutStrategyName) {
+    case ROUND_PAYOUT_MERKLE_OLD:
     case ROUND_PAYOUT_MERKLE:
       return "Quadratic Funding";
       break;
+    case ROUND_PAYOUT_DIRECT_OLD:
     case ROUND_PAYOUT_DIRECT:
       return "Direct Grants";
       break;

--- a/packages/grant-explorer/src/features/discovery/FilterDropdown.tsx
+++ b/packages/grant-explorer/src/features/discovery/FilterDropdown.tsx
@@ -10,7 +10,7 @@ import {
   RoundStatus,
   getRoundSelectionParamsFromUrlParams,
 } from "./hooks/useFilterRounds";
-import { ROUND_PAYOUT_DIRECT, ROUND_PAYOUT_MERKLE } from "common";
+import { ROUND_PAYOUT_DIRECT_OLD, ROUND_PAYOUT_MERKLE_OLD } from "common";
 import { getFilterLabel } from "./utils/getFilterLabel";
 import { getEnabledChains } from "../../app/chainConfig";
 
@@ -26,11 +26,11 @@ export const FILTER_OPTIONS: RoundFilterUiOption[] = [
     children: [
       {
         label: "Quadratic funding",
-        value: ROUND_PAYOUT_MERKLE,
+        value: ROUND_PAYOUT_MERKLE_OLD,
       },
       {
         label: "Direct grants",
-        value: ROUND_PAYOUT_DIRECT,
+        value: ROUND_PAYOUT_DIRECT_OLD,
       },
     ],
   },

--- a/packages/grant-explorer/src/features/discovery/RoundStrategyBadge.tsx
+++ b/packages/grant-explorer/src/features/discovery/RoundStrategyBadge.tsx
@@ -1,6 +1,8 @@
 import {
   ROUND_PAYOUT_DIRECT,
   ROUND_PAYOUT_MERKLE,
+  ROUND_PAYOUT_DIRECT_OLD,
+  ROUND_PAYOUT_MERKLE_OLD,
   RoundPayoutType,
 } from "common";
 import { getRoundType } from "../api/utils";
@@ -9,6 +11,8 @@ import { Badge } from "../common/styles";
 type Props = { strategyName: RoundPayoutType };
 
 const colorOptions = {
+  [ROUND_PAYOUT_MERKLE_OLD]: "blue",
+  [ROUND_PAYOUT_DIRECT_OLD]: "yellow",
   [ROUND_PAYOUT_MERKLE]: "blue",
   [ROUND_PAYOUT_DIRECT]: "yellow",
 } as const;

--- a/packages/grant-explorer/src/features/discovery/hooks/useFilterRounds.ts
+++ b/packages/grant-explorer/src/features/discovery/hooks/useFilterRounds.ts
@@ -6,7 +6,8 @@ import {
   useRounds,
 } from "../../api/rounds";
 import { createRoundsStatusFilter } from "../utils/createRoundsStatusFilter";
-import { ROUND_PAYOUT_MERKLE } from "common";
+// FIXME: replace with ROUND_PAYOUT_MERKLE when we use the Indexer for the homepage
+import { ROUND_PAYOUT_MERKLE_OLD } from "common";
 import { SWRResponse } from "swr";
 
 export type RoundFilterParams = {
@@ -46,7 +47,7 @@ export const ACTIVE_ROUNDS_FILTER: RoundSelectionParams = {
   orderBy: "matchAmount",
   orderDirection: "desc",
   status: RoundStatus.active,
-  type: ROUND_PAYOUT_MERKLE,
+  type: ROUND_PAYOUT_MERKLE_OLD,
   network: "",
 };
 

--- a/packages/grant-explorer/src/features/discovery/utils/__tests__/getExplorerPageTitle.test.tsx
+++ b/packages/grant-explorer/src/features/discovery/utils/__tests__/getExplorerPageTitle.test.tsx
@@ -1,4 +1,4 @@
-import { ROUND_PAYOUT_DIRECT, ROUND_PAYOUT_MERKLE } from "common";
+import { ROUND_PAYOUT_DIRECT_OLD, ROUND_PAYOUT_MERKLE_OLD } from "common";
 import { getExplorerPageTitle } from "../getExplorerPageTitle";
 import { RoundStatus } from "../../hooks/useFilterRounds";
 
@@ -12,14 +12,14 @@ describe("getExplorerPageTitle", () => {
     expect(
       getExplorerPageTitle({
         status: "",
-        type: ROUND_PAYOUT_MERKLE,
+        type: ROUND_PAYOUT_MERKLE_OLD,
         network: "",
       })
     ).toEqual("Quadratic Funding rounds");
     expect(
       getExplorerPageTitle({
         status: "",
-        type: ROUND_PAYOUT_DIRECT,
+        type: ROUND_PAYOUT_DIRECT_OLD,
         network: "",
       })
     ).toEqual("Direct Grants rounds");
@@ -49,7 +49,7 @@ describe("getExplorerPageTitle", () => {
     expect(
       getExplorerPageTitle({
         status: "active,finished",
-        type: ROUND_PAYOUT_MERKLE,
+        type: ROUND_PAYOUT_MERKLE_OLD,
         network: "",
       })
     ).toEqual("Multiple filters");

--- a/packages/grant-explorer/src/features/discovery/utils/getExplorerPageTitle.ts
+++ b/packages/grant-explorer/src/features/discovery/utils/getExplorerPageTitle.ts
@@ -1,4 +1,4 @@
-import { ROUND_PAYOUT_DIRECT, ROUND_PAYOUT_MERKLE } from "common";
+import { ROUND_PAYOUT_DIRECT_OLD, ROUND_PAYOUT_MERKLE_OLD } from "common";
 import { getFilterLabel } from "./getFilterLabel";
 import { RoundFilterParams, RoundStatus } from "../hooks/useFilterRounds";
 
@@ -8,9 +8,9 @@ export function getExplorerPageTitle(filter: RoundFilterParams): string {
   switch (value) {
     case "":
       return "All rounds";
-    case ROUND_PAYOUT_MERKLE:
+    case ROUND_PAYOUT_MERKLE_OLD:
       return "Quadratic Funding rounds";
-    case ROUND_PAYOUT_DIRECT:
+    case ROUND_PAYOUT_DIRECT_OLD:
       return "Direct Grants rounds";
     case RoundStatus.active:
       return "Active rounds";

--- a/packages/grant-explorer/src/features/discovery/utils/getExplorerPageTitle.ts
+++ b/packages/grant-explorer/src/features/discovery/utils/getExplorerPageTitle.ts
@@ -1,4 +1,9 @@
-import { ROUND_PAYOUT_DIRECT_OLD, ROUND_PAYOUT_MERKLE_OLD } from "common";
+import {
+  ROUND_PAYOUT_DIRECT_OLD,
+  ROUND_PAYOUT_MERKLE_OLD,
+  ROUND_PAYOUT_DIRECT,
+  ROUND_PAYOUT_MERKLE,
+} from "common";
 import { getFilterLabel } from "./getFilterLabel";
 import { RoundFilterParams, RoundStatus } from "../hooks/useFilterRounds";
 
@@ -9,8 +14,10 @@ export function getExplorerPageTitle(filter: RoundFilterParams): string {
     case "":
       return "All rounds";
     case ROUND_PAYOUT_MERKLE_OLD:
+    case ROUND_PAYOUT_MERKLE:
       return "Quadratic Funding rounds";
     case ROUND_PAYOUT_DIRECT_OLD:
+    case ROUND_PAYOUT_DIRECT:
       return "Direct Grants rounds";
     case RoundStatus.active:
       return "Active rounds";

--- a/packages/grant-explorer/src/features/projects/hooks/useApplication.ts
+++ b/packages/grant-explorer/src/features/projects/hooks/useApplication.ts
@@ -67,7 +67,7 @@ export function mapApplicationToRound(
     // This is missing from the indexer
     payoutStrategy: {
       id: "id",
-      strategyName: "MERKLE",
+      strategyName: application.round.strategyName,
     },
     // These might not be used anywhere in the app
     votingStrategy: "",

--- a/packages/grant-explorer/src/features/projects/hooks/useApplication.ts
+++ b/packages/grant-explorer/src/features/projects/hooks/useApplication.ts
@@ -64,7 +64,6 @@ export function mapApplicationToRound(
     applicationsEndTime: new Date(application.round.applicationsEndTime),
     roundMetadata: application.round.roundMetadata,
     token: application.round.matchTokenAddress,
-    // This is missing from the indexer
     payoutStrategy: {
       id: "id",
       strategyName: application.round.strategyName,

--- a/packages/grant-explorer/src/features/round/__tests__/ViewProjectDetails.test.tsx
+++ b/packages/grant-explorer/src/features/round/__tests__/ViewProjectDetails.test.tsx
@@ -118,6 +118,7 @@ const expectedProject: Application = {
   },
   projectId: faker.finance.ethereumAddress(),
   round: {
+    strategyName: "allov1.QF",
     applicationsEndTime: new Date().valueOf().toString(),
     applicationsStartTime: new Date().valueOf().toString(),
     donationsEndTime: new Date().valueOf().toString(),


### PR DESCRIPTION
This PR fixes the round typevalue that was hardcoded to merkle and remove the checkout box from the sidebar of the application page in case it's a direct grants round.

Direct Grant application example (replace the domain with the one from the preview link):
https://explorer.gitcoin.co/#/round/42161/0x6142eedc06d80f3b362ce43b4ac52fad679dc850/0x6142eedc06d80f3b362ce43b4ac52fad679dc850-22

QF Round application (replace the domain with the one from the preview link):
https://explorer.gitcoin.co/#/round/10/0xf89aad3fad6c3e79ffa3ccc835620fcc7e55f919/0xf89aad3fad6c3e79ffa3ccc835620fcc7e55f919-10