### PR TITLE
Load Programs from Indexer

### DIFF
--- a/packages/data-layer/src/data.types.ts
+++ b/packages/data-layer/src/data.types.ts
@@ -107,23 +107,6 @@ export type ProjectRole = {
   projectId: string;
 };
 
-export type Tags = "allo-v1" | "program update";
-
-/**
- * The program type for v1
- **/
-
-export type Program = {
-  id: string;
-  chainId: number;
-  metadata: {
-    name: string;
-  };
-  metadataCid?: MetadataPointer;
-  tags: Tags[];
-  roles: AddressAndRole[];
-};
-
 /**
  * The project type for v2
  *
@@ -185,7 +168,7 @@ export type v2Project = {
    *
    * The tags are used to filter the projects based on the version of Allo.
    */
-  tags: [string];
+  tags: ("allo-v1" | "allo-v2" | "program")[];
   /**
    * The block the project was created at
    */
@@ -197,6 +180,16 @@ export type v2Project = {
   roles: AddressAndRole[];
   nonce?: bigint;
   anchorAddress?: string;
+};
+
+/**
+ * The program type for v1
+ **/
+
+export type Program = Omit<v2Project, "metadata"> & {
+  metadata: {
+    name: string;
+  };
 };
 
 /**

--- a/packages/data-layer/src/queries.ts
+++ b/packages/data-layer/src/queries.ts
@@ -14,7 +14,7 @@ export const getProgramByUserAndTag = gql`
       filter: {
         tags: { contains: [$filterByTag] }
         roles: { some: { address: { equalTo: $address } } }
-        and: { chainId: { equalTo: $chainId } }
+        chainId: { equalTo: $chainId }
       }
     ) {
       id
@@ -39,14 +39,13 @@ export const getProgramByUserAndTag = gql`
  *
  * @returns The programs
  */
-export const getProgramById = gql`
-  query ($alloVersion: [String!]!, $programId: String!, $chainId: Int!) {
+export const getProgramByIdAndUser = gql`
+  query ($userAddress: String!, $programId: String!, $chainId: Int!) {
     projects(
       filter: {
-        tags: { equalTo: $alloVersion }
-        tags: { contains: "program" }
         id: { equalTo: $programId }
-        and: { chainId: { equalTo: $chainId } }
+        roles: { some: { address: { equalTo: $userAddress } } }
+        chainId: { equalTo: $chainId }
       }
     ) {
       id

--- a/packages/round-manager/src/context/program/ReadProgramContext.tsx
+++ b/packages/round-manager/src/context/program/ReadProgramContext.tsx
@@ -76,7 +76,9 @@ const fetchProgramsByAddress = async (
 
 const fetchProgramsById = async (
   dispatch: Dispatch,
+  address: string,
   programId: string,
+  dataLayer: DataLayer,
   walletProvider: Web3Provider
 ) => {
   datadogLogs.logger.info(`fetchProgramsById: programId - ${programId}`);
@@ -86,7 +88,12 @@ const fetchProgramsById = async (
     payload: ProgressStatus.IN_PROGRESS,
   });
   try {
-    const program = await getProgramById(programId, walletProvider);
+    const program = await getProgramById(
+      address,
+      programId,
+      walletProvider,
+      dataLayer
+    );
     dispatch({ type: ActionType.SET_PROGRAMS, payload: [program] });
     dispatch({
       type: ActionType.SET_FETCH_PROGRAM_STATUS,
@@ -173,11 +180,13 @@ export const useProgramById = (
   getProgramByIdError?: Error;
 } => {
   const context = useContext(ReadProgramContext);
+  const dataLayer = useDataLayer();
   if (context === undefined) {
     throw new Error("useProgramById must be used within a ProgramProvider");
   }
 
-  const { provider: walletProvider } = useWallet();
+  const { address, provider: walletProvider } = useWallet();
+
   useEffect(() => {
     if (id) {
       const existingProgram = context.state.programs.find(
@@ -185,7 +194,13 @@ export const useProgramById = (
       );
 
       if (!existingProgram) {
-        fetchProgramsById(context.dispatch, id, walletProvider);
+        fetchProgramsById(
+          context.dispatch,
+          address.toLowerCase(),
+          id,
+          dataLayer,
+          walletProvider
+        );
       }
     }
   }, [id, walletProvider]); // eslint-disable-line react-hooks/exhaustive-deps

--- a/packages/round-manager/src/features/api/__tests__/program.test.ts
+++ b/packages/round-manager/src/features/api/__tests__/program.test.ts
@@ -1,19 +1,9 @@
 import { getProgramById, listPrograms } from "../program";
 import { Program } from "../types";
 import { makeProgramData } from "../../../test-utils";
-import { fetchFromIPFS, CHAINS } from "../utils";
-import { graphql_fetch } from "common";
+import { CHAINS } from "../utils";
 import { ChainId } from "common";
-
-jest.mock("../utils", () => ({
-  ...jest.requireActual("../utils"),
-  fetchFromIPFS: jest.fn(),
-}));
-
-jest.mock("common", () => ({
-  ...jest.requireActual("common"),
-  graphql_fetch: jest.fn(),
-}));
+import { zeroAddress } from "viem";
 
 jest.mock("data-layer", () => ({
   DataLayer: jest.fn().mockImplementation(() => ({
@@ -63,42 +53,28 @@ describe("getProgramById", () => {
       chain: CHAINS[ChainId.MAINNET],
     });
     const programId = expectedProgram.id;
-    (graphql_fetch as jest.Mock).mockResolvedValue({
-      data: {
-        programs: [
-          {
+
+    const actualProgram = await getProgramById(
+      zeroAddress,
+      programId as string,
+      {
+        getNetwork: async () =>
+          // @ts-expect-error Test file
+          Promise.resolve({ chainId: ChainId.MAINNET }),
+      },
+      {
+        getProgramByIdAndUser: jest.fn().mockResolvedValue({
+          program: {
             id: expectedProgram.id,
-            roles: [
-              {
-                accounts: [
-                  {
-                    address: expectedProgram.operatorWallets[0],
-                  },
-                ],
-              },
-            ],
-            metaPtr: {
-              protocol: 1,
-              pointer:
-                "uwijkhxkpkdgkszraqzqvhssqulctxzvntxwconznfkelzbtgtqysrzkehl",
+            roles: [{ address: expectedProgram.operatorWallets[0] }],
+            metadata: {
+              name: expectedProgram.metadata?.name,
             },
           },
-        ],
-      },
-    });
-    (fetchFromIPFS as jest.Mock).mockResolvedValue({
-      name: expectedProgram.metadata?.name,
-    });
-
-    const actualProgram = await getProgramById(programId as string, {
-      getNetwork: async () =>
-        // @ts-expect-error Test file
-        Promise.resolve({ chainId: ChainId.MAINNET }),
-    });
+        }),
+      }
+    );
 
     expect(actualProgram).toEqual(expectedProgram);
-    const graphqlFetchCall = (graphql_fetch as jest.Mock).mock.calls[0];
-    const actualQuery = graphqlFetchCall[0];
-    expect(actualQuery).toContain("id: $programId");
   });
 });

--- a/packages/round-manager/src/features/api/program.ts
+++ b/packages/round-manager/src/features/api/program.ts
@@ -1,10 +1,10 @@
-import { CHAINS, fetchFromIPFS } from "./utils";
+import { CHAINS } from "./utils";
 import { MetadataPointer, Program, Web3Instance } from "./types";
 import { programFactoryContract } from "./contracts";
 import { ethers } from "ethers";
 import { datadogLogs } from "@datadog/browser-logs";
 import { Signer } from "@ethersproject/abstract-signer";
-import { ChainId, graphql_fetch } from "common";
+import { ChainId } from "common";
 import { DataLayer } from "data-layer";
 import { getConfig } from "common/src/config";
 
@@ -30,8 +30,8 @@ export async function listPrograms(
     // fetch programs from indexer
 
     const programsRes = await dataLayer.getProgramsByUser({
-      address: address,
-      chainId: chainId,
+      address,
+      chainId,
       alloVersion: config.allo.version,
     });
 
@@ -66,61 +66,40 @@ export async function listPrograms(
 
 // TODO(shavinac) change params to expect chainId instead of signerOrProvider
 export async function getProgramById(
+  address: string,
   programId: string,
-  signerOrProvider: Web3Instance["provider"]
-): Promise<Program> {
-  try {
-    // fetch chain id
-    const { chainId } = (await signerOrProvider.getNetwork()) as {
-      chainId: ChainId;
-    };
+  signerOrProvider: Web3Instance["provider"],
+  dataLayer: DataLayer
+): Promise<Program | null> {
+  // fetch chain id
+  const { chainId } = (await signerOrProvider.getNetwork()) as {
+    chainId: ChainId;
+  };
 
-    // get the subgraph for program by $programId
-    const res = await graphql_fetch(
-      `
-        query GetPrograms($programId: String) {
-          programs(where: {
-            id: $programId
-          }) {
-            id
-            metaPtr {
-              protocol
-              pointer
-            }
-            roles(where: {
-              role: "0xaa630204f2780b6f080cc77cc0e9c0a5c21e92eb0c6771e709255dd27d6de132"
-            }) {
-              accounts {
-                address
-              }
-            }
-          }
-        }
-      `,
-      chainId,
-      { programId }
-    );
+  // fetch program from indexer
+  const { program: program } = await dataLayer.getProgramByIdAndUser({
+    userAddress: address,
+    programId,
+    chainId,
+  });
 
-    const programDataFromGraph = res.data.programs[0];
-    const metadata = await fetchFromIPFS(programDataFromGraph.metaPtr.pointer);
-
-    return {
-      id: programDataFromGraph.id,
-      metadata,
-      operatorWallets: programDataFromGraph.roles[0].accounts.map(
-        (account: { address: string }) => account.address
-      ),
-      chain: {
-        id: chainId,
-        name: CHAINS[chainId]?.name,
-        logo: CHAINS[chainId]?.logo,
-      },
-    };
-  } catch (error) {
-    datadogLogs.logger.error(`error: getProgramById - ${error}`);
-    console.error("getProgramById", error);
-    throw Error("Unable to fetch program");
+  // no program found
+  if (program === null) {
+    return null;
   }
+
+  return {
+    id: program.id,
+    metadata: program.metadata,
+    operatorWallets: program.roles.map(
+      (role: { address: string }) => role.address
+    ),
+    chain: {
+      id: chainId,
+      name: CHAINS[chainId]?.name,
+      logo: CHAINS[chainId]?.logo,
+    },
+  };
 }
 
 interface DeployProgramContractProps {

--- a/packages/round-manager/src/features/program/CreateProgramPage.tsx
+++ b/packages/round-manager/src/features/program/CreateProgramPage.tsx
@@ -159,6 +159,20 @@ export default function CreateProgram() {
   return (
     <div className="bg-[#F3F3F5]">
       <Navbar />
+      <div className="container mx-auto h-screen px-4 py-16">
+        Creating Allo V2 programs in Manager is not yet supported, as a
+        temporary solution please head over to &nbsp;
+        <a className="underline" href="https://builder.gitcoin.co">
+          Builder
+        </a>{" "}
+        to create a project on Allo V2 and come back here.
+      </div>
+    </div>
+  );
+
+  return (
+    <div className="bg-[#F3F3F5]">
+      <Navbar />
       <div className="container mx-auto h-screen px-4 pt-8">
         <header>
           <div className="flow-root">

--- a/packages/round-manager/src/features/program/CreateProgramPage.tsx
+++ b/packages/round-manager/src/features/program/CreateProgramPage.tsx
@@ -20,6 +20,7 @@ import { useCreateProgram } from "../../context/program/CreateProgramContext";
 import ReactTooltip from "react-tooltip";
 import { CHAINS } from "../api/utils";
 import { ChainId } from "common/src/chain-ids";
+import { getConfig } from "common/src/config";
 
 type FormData = {
   name: string;
@@ -156,19 +157,23 @@ export default function CreateProgram() {
     );
   }
 
-  return (
-    <div className="bg-[#F3F3F5]">
-      <Navbar />
-      <div className="container mx-auto h-screen px-4 py-16">
-        Creating Allo V2 programs in Manager is not yet supported, as a
-        temporary solution please head over to &nbsp;
-        <a className="underline" href="https://builder.gitcoin.co">
-          Builder
-        </a>{" "}
-        to create a project on Allo V2 and come back here.
+  const config = getConfig();
+
+  if (config.allo.version === "allo-v2") {
+    return (
+      <div className="bg-[#F3F3F5]">
+        <Navbar />
+        <div className="container mx-auto h-screen px-4 py-16">
+          Creating Allo V2 programs in Manager is not yet supported, as a
+          temporary solution please head over to &nbsp;
+          <a className="underline" href="https://builder.gitcoin.co">
+            Builder
+          </a>{" "}
+          to create a project on Allo V2 and come back here.
+        </div>
       </div>
-    </div>
-  );
+    );
+  }
 
   return (
     <div className="bg-[#F3F3F5]">

--- a/packages/round-manager/src/features/round/__tests__/CreateRoundPage.test.tsx
+++ b/packages/round-manager/src/features/round/__tests__/CreateRoundPage.test.tsx
@@ -8,6 +8,7 @@ import { useWallet } from "../../common/Auth";
 import * as FormWizardImport from "../../common/FormWizard";
 import { fireEvent, screen } from "@testing-library/react";
 import QuadraticFundingForm from "../QuadraticFundingForm";
+import { DataLayer, DataLayerProvider } from "data-layer";
 
 jest.mock("../../common/Navbar");
 jest.mock("../../common/Auth");
@@ -36,7 +37,12 @@ describe("<CreateRoundPage />", () => {
   it("sends program to form wizard", () => {
     const programs = [makeProgramData({ id: programId })];
 
-    renderWithProgramContext(<CreateRoundPage />, { programs });
+    renderWithProgramContext(
+      <DataLayerProvider client={{} as DataLayer}>
+        <CreateRoundPage />
+      </DataLayerProvider>,
+      { programs }
+    );
 
     const firstFormWizardCall = formWizardSpy.mock.calls[0];
     const firstCallArgument = firstFormWizardCall[0];
@@ -54,7 +60,12 @@ describe("<CreateRoundPage />", () => {
   it("exit button redirects to home", async () => {
     const programs = [makeProgramData({ id: programId })];
 
-    renderWithProgramContext(<CreateRoundPage />, { programs });
+    renderWithProgramContext(
+      <DataLayerProvider client={{} as DataLayer}>
+        <CreateRoundPage />
+      </DataLayerProvider>,
+      { programs }
+    );
 
     const exitButton = await screen.findByText("Exit");
     expect(exitButton).toBeTruthy();
@@ -66,7 +77,12 @@ describe("<CreateRoundPage />", () => {
     const programToChoose = makeProgramData({ id: programId });
     const programs = [makeProgramData(), programToChoose, makeProgramData()];
 
-    renderWithProgramContext(<CreateRoundPage />, { programs });
+    renderWithProgramContext(
+      <DataLayerProvider client={{} as DataLayer}>
+        <CreateRoundPage />
+      </DataLayerProvider>,
+      { programs }
+    );
 
     const firstFormWizardCall = formWizardSpy.mock.calls[0];
     const firstCallArgument = firstFormWizardCall[0];


### PR DESCRIPTION
<!-- Thank you for your pull request! Before marking it as "Ready for review",
please ensure that all items of checklist are satisfied and that CI checks are
passing.  -->

subtask of https://github.com/gitcoinco/grants-stack/issues/2870

## Description

this completes the task to load programs from the indexer and simplifies some things:

- Create program advises user to create a project on Builder (temporary solution until we define the flow)
- Implement loading a single program from the indexer
- Fix and simplify the program types in the data layer

## What to test

- Create a program in Allo V2 doesn't work, you have to use Builder in Allo V2 mode
- Create a program still works for Allo V1
- In the manager homepage, programs should be loaded for Allo V1 and V2
- You should be able to click and view the rounds of a single program

Video of round creation: https://www.loom.com/share/ebaec99b1ed0485dae5ef5ec1bc9bca4

<!-- Describe your changes here. -->

## Checklist

This PR:

- [x] Includes only changes relevant to the original ticket. Significant refactoring needs to be separated.
- [x] Doesn't disable eslint rules.
- [x] Doesn't work around the type checker (including but not limited to: type casts, non-null assertions, `@ts-ignore`, unjustified optional values).
- [x] Doesn't contain commented out code.
- [x] If adding/updating a feature, it adds/updates its test script on Notion.
