### PR TITLE
fix date parsing in builder

### DIFF
--- a/packages/builder/src/actions/rounds.ts
+++ b/packages/builder/src/actions/rounds.ts
@@ -117,11 +117,10 @@ export const loadRound =
     const round = {
       id: version === "allo-v1" ? roundId : v2Round.id,
       address: version === "allo-v1" ? roundId : v2Round.strategyAddress,
-      applicationsStartTime:
-        Date.parse(`${v2Round.applicationsStartTime}Z`) / 1000,
-      applicationsEndTime: Date.parse(`${v2Round.applicationsEndTime}Z`) / 1000,
-      roundStartTime: Date.parse(`${v2Round.donationsStartTime}Z`) / 1000,
-      roundEndTime: Date.parse(`${v2Round.donationsEndTime}Z`) / 1000,
+      applicationsStartTime: Date.parse(v2Round.applicationsStartTime) / 1000,
+      applicationsEndTime: Date.parse(v2Round.applicationsEndTime) / 1000,
+      roundStartTime: Date.parse(v2Round.donationsStartTime) / 1000,
+      roundEndTime: Date.parse(v2Round.donationsEndTime) / 1000,
       token: v2Round.matchTokenAddress,
       roundMetaPtr: {
         protocol: "1",


### PR DESCRIPTION

## Description

indexer dates are now returned with timezone information, adding Z at the end will make it an invalid ISO date

<img width="435" alt="Screenshot 2024-02-21 at 15 28 10" src="https://github.com/gitcoinco/grants-stack/assets/711886/372728e8-1d8f-4837-aa15-111155c60213">


