### PR TITLE
fix(explorer): convert p to div to allow div child elements

### DIFF
--- a/packages/grant-explorer/src/features/round/ViewRoundPage.tsx
+++ b/packages/grant-explorer/src/features/round/ViewRoundPage.tsx
@@ -299,7 +299,7 @@ function AfterRoundStart(props: {
                 </p>
               </div>
 
-              <p className="text-grey-400 text-sm flex gap-2 mb-4">
+              <div className="text-grey-400 text-sm flex gap-2 mb-4">
                 <span>Deployed on:</span>
                 <div className="flex">
                   <img
@@ -309,7 +309,7 @@ function AfterRoundStart(props: {
                   />
                   <span>{CHAINS[chainId]?.name}</span>
                 </div>
-              </p>
+              </div>
 
               {!isDirectRound(round) && (
                 <p className="text-1xl mb-4">


### PR DESCRIPTION
Remove invalid html console warnings converting a `p` tag to `div` to allow `div` child elements