### PR TITLE
fix goto definition

### DIFF
--- a/packages/common/tsconfig.json
+++ b/packages/common/tsconfig.json
@@ -16,6 +16,7 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "react-jsx",
+    "declarationMap": true,
     "sourceMap": true,
     "declaration": true,
     "incremental": true

--- a/packages/data-layer/tsconfig.json
+++ b/packages/data-layer/tsconfig.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "outDir": "dist",
     "declaration": true,
+    "declarationMap": true,
     "sourceMap": true,
     "jsx": "react-jsx",
     "incremental": true


### PR DESCRIPTION
this fixes LSP go to definition when going from one of the dapps to common / data-layer, at the moment when you go to defintion it goes to the `dist` files instead of the source files (like `common/dist/allo.d.ts` instead of `common/src/allo.ts`, which is annoying because you cannot change the source, you have to find the source file manually