### PR TITLE
fix(Manager): treat IN_REVIEW status as pending for the round contract

### DIFF
--- a/packages/common/src/allo/backends/allo-v1.ts
+++ b/packages/common/src/allo/backends/allo-v1.ts
@@ -62,6 +62,7 @@ function createProjectId(args: {
 function applicationStatusToNumber(status: ApplicationStatus) {
   switch (status) {
     case "PENDING":
+    case "IN_REVIEW":
       return 0n;
     case "APPROVED":
       return 1n;

--- a/packages/common/src/allo/backends/allo-v2.ts
+++ b/packages/common/src/allo/backends/allo-v2.ts
@@ -12,7 +12,11 @@ import {
   TransactionData,
 } from "@allo-team/allo-v2-sdk";
 import { CreatePoolArgs, NATIVE } from "@allo-team/allo-v2-sdk/dist/types";
-import { ApplicationStatus, RoundApplicationAnswers, RoundCategory } from "data-layer";
+import {
+  ApplicationStatus,
+  RoundApplicationAnswers,
+  RoundCategory,
+} from "data-layer";
 import { Abi, Address, Hex, PublicClient, getAddress, zeroAddress } from "viem";
 import { AnyJson, ChainId } from "../..";
 import { VotingToken } from "../../types";
@@ -40,6 +44,7 @@ const STRATEGY_ADDRESSES = {
 function applicationStatusToNumber(status: ApplicationStatus) {
   switch (status) {
     case "PENDING":
+    case "IN_REVIEW":
       return 1n;
     case "APPROVED":
       return 2n;


### PR DESCRIPTION
Fixes: #3099

Test round in case you want to test it manually: https://grants-stack-manager-staging.vercel.app/#/round/0x11f747e641613b86d1db25d53ea6f963ae53bc58

An error happens when applications are moved from `In Review` to other statuses and at least `1` application is left in `In Review`.

This PR fixes it treating `IN_REVIEW` as a `PENDING` status, since `IN_REVIEW` is not a core status in the round contract
