### PR TITLE
implement "reclaim fund" on the allo wrapper

### DIFF
--- a/packages/common/src/allo/allo.ts
+++ b/packages/common/src/allo/allo.ts
@@ -156,6 +156,18 @@ export interface Allo {
     }
   >;
 
+  withdrawFundsFromStrategy: (args: {
+    payoutStrategyAddress: Address;
+    recipientAddress: Address;
+  }) => AlloOperation<
+    Result<null>,
+    {
+      transaction: Result<Hex>;
+      transactionStatus: Result<TransactionReceipt>;
+      indexingStatus: Result<null>;
+    }
+  >;
+
   finalizeRound: (args: {
     roundId: string;
     strategyAddress: Address;

--- a/packages/common/src/allo/backends/allo-v2.ts
+++ b/packages/common/src/allo/backends/allo-v2.ts
@@ -774,6 +774,23 @@ export class AlloV2 implements Allo {
     });
   }
 
+  withdrawFundsFromStrategy(_args: {
+    payoutStrategyAddress: Address;
+    recipientAddress: Address;
+  }): AlloOperation<
+    Result<null>,
+    {
+      tokenApprovalStatus: Result<TransactionReceipt | null>;
+      transaction: Result<Hex>;
+      transactionStatus: Result<TransactionReceipt>;
+      indexingStatus: Result<null>;
+    }
+  > {
+    return new AlloOperation(async () => {
+      throw new Error("not implemented.");
+    });
+  }
+
   finalizeRound(args: {
     roundId: string;
     strategyAddress: Address;

--- a/packages/round-manager/src/context/round/ReclaimFundsContext.tsx
+++ b/packages/round-manager/src/context/round/ReclaimFundsContext.tsx
@@ -78,7 +78,7 @@ export const useReclaimFunds = () => {
   };
 };
 
-export const _reclaimFunds = async ({
+const _reclaimFunds = async ({
   allo,
   payoutStrategy,
   recipient,

--- a/packages/round-manager/src/context/round/ReclaimFundsContext.tsx
+++ b/packages/round-manager/src/context/round/ReclaimFundsContext.tsx
@@ -78,7 +78,7 @@ export const useReclaimFunds = () => {
   };
 };
 
-const _reclaimFunds = async ({
+export const _reclaimFunds = async ({
   allo,
   payoutStrategy,
   recipient,

--- a/packages/round-manager/src/context/round/__tests__/ReclaimFundsContext.test.tsx
+++ b/packages/round-manager/src/context/round/__tests__/ReclaimFundsContext.test.tsx
@@ -1,14 +1,29 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { reclaimFundsFromContract } from "../../../features/api/payoutStrategy/payoutStrategy";
 import { ProgressStatus } from "../../../features/api/types";
 import {
   ReclaimFundsParams,
   ReclaimFundsProvider,
   useReclaimFunds,
 } from "../ReclaimFundsContext";
+import { error, success } from "common/dist/allo/common";
+import {
+  AlloV1,
+  createMockTransactionSender,
+  useAllo,
+  AlloOperation,
+} from "common";
 
 jest.mock("wagmi");
 jest.mock("../../../features/api/payoutStrategy/payoutStrategy");
+
+jest.mock("viem", () => ({
+  getAddress: jest.fn(),
+}));
+
+jest.mock("common", () => ({
+  ...jest.requireActual("common"),
+  useAllo: jest.fn(),
+}));
 
 const mockSigner = {
   getChainId: () => {
@@ -19,20 +34,32 @@ jest.mock("wagmi", () => ({
   useSigner: () => ({ data: mockSigner }),
 }));
 
+const alloBackend = new AlloV1({
+  chainId: 1,
+  ipfsUploader: async () =>
+    Promise.resolve({
+      type: "success",
+      value: "ipfsHash",
+    }),
+  waitUntilIndexerSynced: jest.fn(),
+  transactionSender: createMockTransactionSender(),
+});
+
 const testParams: ReclaimFundsParams = {
-  payoutStrategy: "testPayoutStrategy",
-  recipientAddress: "0x1234567890123456789012345678901234567890",
+  allo: alloBackend,
+  payoutStrategy: "0x0000000000000000000000000000000000000001",
+  recipient: "0x0000000000000000000000000000000000000002",
 };
 
 describe("<ReclaimFundsProvider />", () => {
   beforeEach(() => {
     jest.resetAllMocks();
 
-    (reclaimFundsFromContract as jest.Mock).mockReturnValue(
-      new Promise(() => {
-        /* do nothing.*/
-      })
-    );
+    alloBackend.withdrawFundsFromStrategy = jest.fn().mockImplementation(() => {
+      return new AlloOperation(async ({ emit }) => {
+        return success(null);
+      });
+    });
   });
 
   it("renders without crashing", () => {
@@ -67,7 +94,11 @@ describe("useReclaimFunds Errors", () => {
   });
 
   it("sets reclaim status to error when invoking fund fails", async () => {
-    (reclaimFundsFromContract as jest.Mock).mockRejectedValue(new Error(":("));
+    alloBackend.withdrawFundsFromStrategy = jest.fn().mockImplementation(() => {
+      return new AlloOperation(async ({ emit }) => {
+        return error(new Error("test error"));
+      });
+    });
 
     renderWithProvider(<TestUseReclaimFundsComponent {...testParams} />);
 
@@ -79,13 +110,11 @@ describe("useReclaimFunds Errors", () => {
   });
 
   it("if reclaim fails, resets reclaim status when reclaim contract is retried", async () => {
-    (reclaimFundsFromContract as jest.Mock)
-      .mockRejectedValueOnce(new Error(":("))
-      .mockReturnValue(
-        new Promise(() => {
-          /* do nothing.*/
-        })
-      );
+    alloBackend.withdrawFundsFromStrategy = jest.fn().mockImplementation(() => {
+      return new AlloOperation(async ({ emit }) => {
+        return error(new Error("test error"));
+      });
+    });
 
     renderWithProvider(<TestUseReclaimFundsComponent {...testParams} />);
     fireEvent.click(screen.getByTestId("reclaim-funds"));

--- a/packages/round-manager/src/features/api/payoutStrategy/payoutStrategy.ts
+++ b/packages/round-manager/src/features/api/payoutStrategy/payoutStrategy.ts
@@ -122,39 +122,3 @@ export const useGroupProjectsByPaymentStatus = (
   }, [allProjects]);
   return groupedProjects;
 };
-
-/**
- * Reclaims funds from contract to provided address
- *
- * @param payoutStrategy
- * @param signerOrProvider
- * @param recipient
- * @returns
- */
-export async function reclaimFundsFromContract(
-  payoutStrategy: string,
-  signerOrProvider: Signer,
-  recipient: string
-) {
-  try {
-    const merklePayoutStrategyImplementation = new ethers.Contract(
-      payoutStrategy,
-      merklePayoutStrategyImplementationContract.abi,
-      signerOrProvider
-    );
-
-    const tx =
-      await merklePayoutStrategyImplementation.withdrawFunds(recipient);
-
-    const receipt = await tx.wait();
-
-    console.log("✅ Transaction hash: ", tx.hash);
-    const blockNumber = receipt.blockNumber;
-    return {
-      transactionBlockNumber: blockNumber,
-    };
-  } catch (error) {
-    console.error("reclaimFundsFromContract", error);
-    throw new Error("Unable to reclaim funds from round");
-  }
-}

--- a/packages/round-manager/src/features/round/ReclaimFunds.tsx
+++ b/packages/round-manager/src/features/round/ReclaimFunds.tsx
@@ -16,6 +16,7 @@ import { AdditionalGasFeesNote } from "./BulkApplicationCommon";
 import { useTokenPrice } from "common";
 import { assertAddress } from "common/src/address";
 import { payoutTokens } from "../api/payoutTokens";
+import { useAllo } from "common";
 
 export default function ReclaimFunds(props: {
   round: Round | undefined;
@@ -90,6 +91,8 @@ function ReclaimFundsContent(props: {
   >();
   const [transactionReplaced, setTransactionReplaced] = useState(false);
 
+  const allo = useAllo();
+
   const { reclaimFunds, reclaimStatus } = useReclaimFunds();
 
   const payoutStrategy = props.round?.payoutStrategy.id ?? "";
@@ -117,10 +120,15 @@ function ReclaimFundsContent(props: {
   }, [navigate, transactionReplaced, props.roundId, reclaimStatus]);
 
   async function handleSubmitFund() {
+    if (allo === null) {
+      return;
+    }
+
     try {
       await reclaimFunds({
+        allo,
         payoutStrategy,
-        recipientAddress: walletAddress,
+        recipient: walletAddress,
       });
     } catch (error) {
       if (error === Logger.errors.TRANSACTION_REPLACED) {

--- a/packages/round-manager/src/features/round/__tests__/ReclaimFunds.test.tsx
+++ b/packages/round-manager/src/features/round/__tests__/ReclaimFunds.test.tsx
@@ -48,7 +48,9 @@ jest.mock("common", () => ({
 
 jest.mock("data-layer", () => ({
   ...jest.requireActual("data-layer"),
-  useDataLayer: () => ({}),
+  useDataLayer: () => ({
+    getApplicationsForManager: () => [],
+  }),
   useApplicationsByRoundId: () => {},
 }));
 
@@ -104,19 +106,16 @@ describe("ReclaimFunds", () => {
         error: null,
         loading: false,
       }));
-
       (useBalance as jest.Mock).mockImplementation(() => ({
         data: { formatted: "0", value: "0" },
         error: null,
         loading: false,
       }));
-
       (useSigner as jest.Mock).mockImplementation(() => ({
         signer: {
           getBalance: () => Promise.resolve("0"),
         },
       }));
-
       render(
         wrapWithBulkUpdateGrantApplicationContext(
           wrapWithReadProgramContext(
@@ -130,7 +129,6 @@ describe("ReclaimFunds", () => {
       );
       const fundContractTab = screen.getByTestId("reclaim-funds");
       fireEvent.click(fundContractTab);
-
       expect(screen.getByTestId("reclaim-funds-title")).toBeInTheDocument();
       expect(screen.getByText("Contract Balance")).toBeInTheDocument();
       expect(screen.getByText("Payout token:")).toBeInTheDocument();


### PR DESCRIPTION
Fixes: #3138

How to test it:

* switch to Sepolia in your wallet
* open round in Manager `0xb00abdd04cb58b2a8e15d4e382548ee81f5632c4`
* go to the Reclaim Funds tab, it should show `Amount in payout contract: 0 ETH`
* send 0.01 ETH to the Payout Strategy (`0xCa1Cd1cD347a6a2673Ec80Ba0c77e058008e1caA`) with a normal tx from the wallet (without having to use Manager)
* refresh the "Reclaim Funds" tab, it should show `Amount in payout contract: 0.01 ETH`
* Enter your wallet address, click the "Reclaim funds" button and confirm the tx
* Your should receive 0.01 back
