### PR TITLE
2919/disable matching stats for avax

### DIFF
--- a/packages/grant-explorer/src/features/round/ViewCartPage/SummaryContainer.tsx
+++ b/packages/grant-explorer/src/features/round/ViewCartPage/SummaryContainer.tsx
@@ -2,7 +2,6 @@ import { ChainId, getTokenPrice, NATIVE } from "common";
 import { useCartStorage } from "../../../store";
 import { useEffect, useMemo, useState } from "react";
 import { Summary } from "./Summary";
-import ErrorModal from "../../common/ErrorModal";
 import ChainConfirmationModal from "../../common/ConfirmationModal";
 import { ChainConfirmationModalBody } from "./ChainConfirmationModalBody";
 import { ProgressStatus } from "../../api/types";
@@ -12,7 +11,6 @@ import { useAccount, useWalletClient } from "wagmi";
 import { Button } from "common/src/styles";
 import { InformationCircleIcon } from "@heroicons/react/24/solid";
 import { BoltIcon } from "@heroicons/react/24/outline";
-
 import { getClassForPassportColor } from "../../api/passport";
 import useSWR from "swr";
 import { groupBy, uniqBy } from "lodash-es";
@@ -371,9 +369,10 @@ export function SummaryContainer() {
       const projectFromRound = projects.find(
         (project) => project.roundId === round.id
       );
+
       return {
         roundId: getFormattedRoundId(round.id),
-        chainId: projectFromRound?.chainId ?? ChainId.MAINNET,
+        chainId: projectFromRound?.chainId ?? round.chainId ?? ChainId.MAINNET,
         potentialVotes: projects
           .filter((proj) => proj.roundId === round.id)
           .map((proj) => ({
@@ -393,11 +392,17 @@ export function SummaryContainer() {
       };
     }) ?? [];
 
+  /* Filter out the chains that are not supported by the matching estimates API */
+  const excludedChains = [43114, 43113];
+  const filteredMatchingEstimates = matchingEstimateParamsPerRound.filter(
+    (est) => !excludedChains.includes(est.chainId)
+  );
+
   const {
     data,
     error: matchingEstimateError,
     isLoading: matchingEstimateLoading,
-  } = useMatchingEstimates(matchingEstimateParamsPerRound);
+  } = useMatchingEstimates(filteredMatchingEstimates);
 
   const matchingEstimates = data?.length && data.length > 0 ? data : undefined;
   const estimate = matchingEstimatesToText(matchingEstimates);

--- a/packages/round-manager/src/features/round/ViewRoundStats.tsx
+++ b/packages/round-manager/src/features/round/ViewRoundStats.tsx
@@ -17,7 +17,9 @@ export default function ViewRoundStats() {
   const chainId = useChainId();
   const alloVersion = getConfig().allo.version;
   const roundId =
-    alloVersion === "allo-v1" ? utils.getAddress(id?.toLowerCase() ?? "") : id as string;
+    alloVersion === "allo-v1"
+      ? utils.getAddress(id?.toLowerCase() ?? "")
+      : (id as string);
 
   const { data: round } = useRound(roundId);
   const { data: applications } = useRoundApplications(roundId);
@@ -34,6 +36,9 @@ export default function ViewRoundStats() {
         t.address.toLowerCase() == round.token.toLowerCase() &&
         t.chainId === chainId
     );
+
+  // check if the round is on Avalanche to prevent matching stats from being displayed
+  const isAvaxRound: boolean = chainId === 43114 || chainId === 43113;
 
   return (
     <div className="flex flex-center flex-col mx-auto mt-3 mb-[212px]">
@@ -99,30 +104,32 @@ export default function ViewRoundStats() {
                 </th>
               </tr>
             </thead>
-            <tbody>
-              {round &&
-                matches &&
-                matches.map((match: Match) => {
-                  const percentage =
-                    Number(
-                      (BigInt(1000000) * match.matched) / round.matchAmount
-                    ) / 10000;
+            {!isAvaxRound && (
+              <tbody>
+                {round &&
+                  matches &&
+                  matches.map((match: Match) => {
+                    const percentage =
+                      Number(
+                        (BigInt(1000000) * match.matched) / round.matchAmount
+                      ) / 10000;
 
-                  return (
-                    <tr key={match.applicationId}>
-                      <td className="text-sm leading-5 text-gray-400 text-left">
-                        {match.projectName}
-                      </td>
-                      <td className="text-sm leading-5 text-gray-400 text-left">
-                        {match.contributionsCount}
-                      </td>
-                      <td className="text-sm leading-5 text-gray-400 text-left">
-                        {percentage.toString()}%
-                      </td>
-                    </tr>
-                  );
-                })}
-            </tbody>
+                    return (
+                      <tr key={match.applicationId}>
+                        <td className="text-sm leading-5 text-gray-400 text-left">
+                          {match.projectName}
+                        </td>
+                        <td className="text-sm leading-5 text-gray-400 text-left">
+                          {match.contributionsCount}
+                        </td>
+                        <td className="text-sm leading-5 text-gray-400 text-left">
+                          {percentage.toString()}%
+                        </td>
+                      </tr>
+                    );
+                  })}
+              </tbody>
+            )}
           </table>
         </div>
         <div className="col-span-1 row-span-2 grid gap-y-6">


### PR DESCRIPTION
Fixes: #2919 

## Description

- [x] Update round manager to not show matching round stats when on Avalanche.
- To test: In round manager, go to an Avalanche round and view your round stats. The matching stats should not show up and no error should occur.
- [x] Update grant explorer to not show the matching stats for rounds on Avalanche.

## Checklist

This PR:

- [x] Does it add new payout or donation token? In this case, have they been added to the indexer to avoid it to crash?
- [x] Includes only changes relevant to the original ticket. Significant refactoring needs to be separated.
- [x] Doesn't disable eslint rules.
- [x] Doesn't work around the type checker (including but not limited to: type casts, non-null assertions, `@ts-ignore`, unjustified optional values).
- [x] Doesn't contain commented out code.
- [x] If adding/updating a feature, it adds/updates its test script on Notion.
