### PR TITLE
fix unsupported chains in allov2

### DIFF
--- a/packages/builder/src/utils/AlloWrapper.tsx
+++ b/packages/builder/src/utils/AlloWrapper.tsx
@@ -3,10 +3,10 @@ import {
   AlloProvider,
   AlloV1,
   AlloV2,
-  ChainId,
   createEthersTransactionSender,
   createPinataIpfsUploader,
   createWaitForIndexerSyncTo,
+  isChainIdSupported,
 } from "common";
 import { getConfig } from "common/src/config";
 import { useEffect, useState } from "react";
@@ -22,17 +22,17 @@ function AlloWrapper({ children }: { children: JSX.Element | JSX.Element[] }) {
   const [backend, setBackend] = useState<Allo | null>(null);
 
   useEffect(() => {
-    if (!web3Provider || !signer || !chainID) {
+    const chainIdSupported = chainID ? isChainIdSupported(chainID) : false;
+
+    if (!web3Provider || !signer || !chainID || !chainIdSupported) {
       setBackend(null);
     } else {
-      const chainIdSupported = Object.values(ChainId).includes(chainID);
-
       const config = getConfig();
       let alloBackend: Allo;
 
       if (config.allo.version === "allo-v2") {
         alloBackend = new AlloV2({
-          chainId: chainIdSupported ? chainID : 1,
+          chainId: chainID,
           transactionSender: createEthersTransactionSender(
             signer,
             web3Provider
@@ -49,7 +49,7 @@ function AlloWrapper({ children }: { children: JSX.Element | JSX.Element[] }) {
         setBackend(alloBackend);
       } else {
         alloBackend = new AlloV1({
-          chainId: chainIdSupported ? chainID : 1,
+          chainId: chainID,
           transactionSender: createEthersTransactionSender(
             signer,
             web3Provider

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -5,6 +5,7 @@ import { useParams as useRouterParams } from "react-router";
 import { useOutletContext } from "react-router-dom";
 import z from "zod";
 import { ChainId } from "./chain-ids";
+import { getAlloVersion } from "./config";
 
 export * from "./icons";
 export * from "./markdown";
@@ -409,3 +410,10 @@ export const txBlockExplorerLinks: Record<ChainId, string> = {
 export const getTxBlockExplorerLink = (chainId: ChainId, txHash: string) => {
   return txBlockExplorerLinks[chainId] + txHash;
 };
+
+export function isChainIdSupported(chainId: number) {
+  if (chainId === 424 && getAlloVersion() === "allo-v2") {
+    return false;
+  }
+  return Object.values(ChainId).includes(chainId);
+}

--- a/packages/grant-explorer/src/features/api/AlloWrapper.tsx
+++ b/packages/grant-explorer/src/features/api/AlloWrapper.tsx
@@ -2,10 +2,10 @@ import {
   Allo,
   AlloV1,
   AlloV2,
-  ChainId,
   createPinataIpfsUploader,
   createViemTransactionSender,
   createWaitForIndexerSyncTo,
+  isChainIdSupported,
 } from "common";
 import { getConfig } from "common/src/config";
 import React, { createContext, useContext, useEffect, useState } from "react";
@@ -20,17 +20,17 @@ function AlloWrapper({ children }: { children: JSX.Element | JSX.Element[] }) {
   const [backend, setBackend] = useState<Allo | null>(null);
 
   useEffect(() => {
-    if (!publicClient || !walletClient || !chainID) {
+    const chainIdSupported = chainID ? isChainIdSupported(chainID) : false;
+
+    if (!publicClient || !walletClient || !chainID || !chainIdSupported) {
       setBackend(null);
     } else {
-      const chainIdSupported = Object.values(ChainId).includes(chainID);
-
       const config = getConfig();
       let alloBackend: Allo;
 
       if (config.allo.version === "allo-v2") {
         alloBackend = new AlloV2({
-          chainId: chainIdSupported ? chainID : 1,
+          chainId: chainID,
           transactionSender: createViemTransactionSender(
             walletClient,
             publicClient
@@ -47,7 +47,7 @@ function AlloWrapper({ children }: { children: JSX.Element | JSX.Element[] }) {
         setBackend(alloBackend);
       } else {
         alloBackend = new AlloV1({
-          chainId: chainIdSupported ? chainID : 1,
+          chainId: chainID,
           transactionSender: createViemTransactionSender(
             walletClient,
             publicClient

--- a/packages/round-manager/src/features/api/AlloWrapper.tsx
+++ b/packages/round-manager/src/features/api/AlloWrapper.tsx
@@ -7,6 +7,7 @@ import {
   createEthersTransactionSender,
   createPinataIpfsUploader,
   createWaitForIndexerSyncTo,
+  isChainIdSupported,
 } from "common";
 import { useNetwork, useProvider, useSigner } from "wagmi";
 import { getConfig } from "common/src/config";
@@ -20,18 +21,18 @@ function AlloWrapper({ children }: { children: JSX.Element | JSX.Element[] }) {
   const chainID = chain?.id;
 
   const backend = useMemo(() => {
-    if (!web3Provider || !signer || !chainID) {
+    const chainIdSupported = chainID ? isChainIdSupported(chainID) : false;
+
+    if (!web3Provider || !signer || !chainID || !chainIdSupported) {
       return null;
     }
 
     const config = getConfig();
     let alloBackend: Allo;
 
-    const chainIdSupported = Object.values(ChainId).includes(chainID);
-
     if (config.allo.version === "allo-v2") {
       alloBackend = new AlloV2({
-        chainId: chainIdSupported ? chainID : 1,
+        chainId: chainID,
         transactionSender: createEthersTransactionSender(signer, web3Provider),
         ipfsUploader: createPinataIpfsUploader({
           token: getConfig().pinata.jwt,
@@ -43,7 +44,7 @@ function AlloWrapper({ children }: { children: JSX.Element | JSX.Element[] }) {
       });
     } else {
       alloBackend = new AlloV1({
-        chainId: chainIdSupported ? chainID : 1,
+        chainId: chainID,
         transactionSender: createEthersTransactionSender(signer, web3Provider),
         ipfsUploader: createPinataIpfsUploader({
           token: getConfig().pinata.jwt,


### PR DESCRIPTION
currently loading explorer & manager with PGN renders a blank page
this also fixes the hack of loading mainnet, which could bring other problems downstream

how to test:

- open explorer with allo v2
- choose pgn
- it shouldn't crash

we might have to look at doing something more elaborate in the future, like showing "unsupported network" but at least without crashing you can still change the network to something else
