### PR TITLE
chore:enable reapply

### DIFF
--- a/packages/builder/src/components/application/Form.tsx
+++ b/packages/builder/src/components/application/Form.tsx
@@ -38,6 +38,7 @@ import FormValidationErrorList from "../base/FormValidationErrorList";
 import InputLabel from "../base/InputLabel";
 import LoadingSpinner from "../base/LoadingSpinner";
 import { validateApplication } from "../base/formValidation";
+import { getConfig } from "common/src/config";
 import Checkbox from "../grants/Checkbox";
 import Radio from "../grants/Radio";
 import Toggle from "../grants/Toggle";
@@ -83,6 +84,7 @@ export default function Form({
   const dispatch = useDispatch();
   const dataLayer = useDataLayer();
   const { chains } = useNetwork();
+  const { version } = getConfig().allo;
 
   const [projectApplications, setProjectApplications] = useState<
     ProjectApplicationWithRound[]
@@ -265,7 +267,9 @@ export default function Form({
       projectApplications.filter((app) => app.projectId === projectId).length >
       0;
 
-    setHasExistingApplication(hasProjectAppliedToRound);
+    if (version === "allo-v1") {
+      setHasExistingApplication(hasProjectAppliedToRound);
+    }
     setIsLoading(false);
     handleInput(e);
   };

--- a/packages/builder/src/components/application/Form.tsx
+++ b/packages/builder/src/components/application/Form.tsx
@@ -1,5 +1,6 @@
 import { Stack } from "@chakra-ui/react";
 import { datadogRum } from "@datadog/browser-rum";
+import { getConfig } from "common/src/config";
 import { ExclamationCircleIcon } from "@heroicons/react/20/solid";
 import {
   ExclamationTriangleIcon,
@@ -38,7 +39,6 @@ import FormValidationErrorList from "../base/FormValidationErrorList";
 import InputLabel from "../base/InputLabel";
 import LoadingSpinner from "../base/LoadingSpinner";
 import { validateApplication } from "../base/formValidation";
-import { getConfig } from "common/src/config";
 import Checkbox from "../grants/Checkbox";
 import Radio from "../grants/Radio";
 import Toggle from "../grants/Toggle";
@@ -267,7 +267,7 @@ export default function Form({
       projectApplications.filter((app) => app.projectId === projectId).length >
       0;
 
-    if (version === "allo-v1") {
+    if (version === "allo-v2") {
       setHasExistingApplication(hasProjectAppliedToRound);
     }
     setIsLoading(false);


### PR DESCRIPTION
This enables reapply only for allo-v2 so that it doesn't break existing flow on v1.
Note: This needs the indexer to be update to be able to track UpdatedRegistration event which is not indexed currently

Here is a sample round:
https://grants-stack-manager-staging.vercel.app/#/round/98
And the project with which I've reapplied
http://localhost:3000/#/chains/11155111/registry/0x/projects/0x663a65b17790c882b4606a423641381db8cbb692f35869344bc35b172c36f364

- [x] applied to round
- [x] rejected project
- [x] reapplied to round

Fixes: https://github.com/gitcoinco/grants-stack/issues/3254

He