### PR TITLE
Adds OP token for OP mainnet

### DIFF
--- a/packages/common/src/chain-ids.ts
+++ b/packages/common/src/chain-ids.ts
@@ -37,4 +37,5 @@ export const RedstoneTokenIds = {
   mkUSD: "mkUSD",
   DATA: "DATA",
   USDGLO: "USDGLO",
+  OP: "OP",
 } as const;

--- a/packages/grant-explorer/src/features/api/utils.ts
+++ b/packages/grant-explorer/src/features/api/utils.ts
@@ -12,7 +12,6 @@ import { RedstoneTokenIds } from "common/src/chain-ids";
 import { useSearchParams } from "react-router-dom";
 import { getAddress, zeroAddress } from "viem";
 import { ethers } from "ethers";
-import { f } from "vitest/dist/reporters-2ff87305";
 
 export function useDebugMode(): boolean {
   const [searchParams] = useSearchParams();

--- a/packages/grant-explorer/src/features/api/utils.ts
+++ b/packages/grant-explorer/src/features/api/utils.ts
@@ -6,15 +6,13 @@ import {
   NATIVE,
   ROUND_PAYOUT_DIRECT,
   ROUND_PAYOUT_DIRECT_OLD,
-  ROUND_PAYOUT_MERKLE,
-  ROUND_PAYOUT_MERKLE_OLD,
-  RoundPayoutTypeNew,
   VotingToken,
 } from "common";
 import { RedstoneTokenIds } from "common/src/chain-ids";
 import { useSearchParams } from "react-router-dom";
 import { getAddress, zeroAddress } from "viem";
 import { ethers } from "ethers";
+import { f } from "vitest/dist/reporters-2ff87305";
 
 export function useDebugMode(): boolean {
   const [searchParams] = useSearchParams();
@@ -258,6 +256,16 @@ export const OPTIMISM_MAINNET_TOKENS: VotingToken[] = [
     defaultForVoting: true,
     canVote: true,
   },
+  {
+    name: "OP",
+    chainId: ChainId.OPTIMISM_MAINNET_CHAIN_ID,
+    address: "0x4200000000000000000000000000000000000042",
+    decimal: 18,
+    logo: TokenNamesAndLogos["OP"],
+    redstoneTokenId: RedstoneTokenIds["OP"],
+    defaultForVoting: false,
+    canVote: true,
+  }
 ];
 
 const FANTOM_MAINNET_TOKENS: VotingToken[] = [


### PR DESCRIPTION
Fixes: #3271 

## Description

Adds the ability to donate with OP token on Optimism mainnet.

## Checklist

This PR:

- [x] Does it add new payout or donation token? In this case, have they been added to the indexer to avoid it to crash?
- [x] Includes only changes relevant to the original ticket. Significant refactoring needs to be separated.
- [x] Doesn't disable eslint rules.
- [x] Doesn't work around the type checker (including but not limited to: type casts, non-null assertions, `@ts-ignore`, unjustified optional values).
- [x] Doesn't contain commented out code.
- [x] If adding/updating a feature, it adds/updates its test script on Notion.



<img width="1979" alt="Screenshot 2024-04-08 at 2 01 57 PM" src="https://github.com/gitcoinco/grants-stack/assets/9419140/5e35b14a-5871-473e-914e-8e675b628051">

![Screenshot 2024-04-08 at 3 04 43 PM](https://github.com/gitcoinco/grants-stack/assets/9419140/7c04dae2-367b-464c-9286-500d29025529)