### PR TITLE
3307/ remove matching stat card

### DIFF
--- a/packages/grant-explorer/src/features/contributors/ViewContributionHistory.tsx
+++ b/packages/grant-explorer/src/features/contributors/ViewContributionHistory.tsx
@@ -233,7 +233,7 @@ export function ViewContributionHistory(props: {
         </div>
         {/*  */}
         <div className="text-2xl my-6 font-sans">Donation Impact</div>
-        <div className="grid grid-cols-2 grid-row-2 lg:grid-cols-4 lg:grid-row-1 gap-6">
+        <div className="grid grid-cols-2 grid-row-2 lg:grid-cols-3 lg:grid-row-1 gap-6">
           <div className="col-span-2 lg:col-span-1">
             <StatCard
               title="Total Donations"
@@ -241,9 +241,9 @@ export function ViewContributionHistory(props: {
             />
           </div>
           {/* todo: get the matching amount */}
-          <div className="col-span-2 lg:col-span-1">
+          {/* <div className="col-span-2 lg:col-span-1">
             <StatCard title="Total Est. Matching" value={"$" + "56M"} />
-          </div>
+          </div> */}
           <div className="col-span-1">
             <StatCard
               title="Contributions"

--- a/packages/grant-explorer/src/features/contributors/ViewContributionHistory.tsx
+++ b/packages/grant-explorer/src/features/contributors/ViewContributionHistory.tsx
@@ -210,7 +210,6 @@ export function ViewContributionHistory(props: {
                 props.address.slice(0, 6) + "..." + props.address.slice(-6)}
             </div>
           </div>
-          {/* todo: update text opacity */}
           <div className="flex justify-between items-center">
             <Button
               className="shadow-sm inline-flex border-gray-300 border-2 bg-gradient-to-br from-[#f6d7caff] via-[#bddce8ff] to-[#ebdfa5ff] font-medium py-2 px-4 rounded-md hover:bg-gradient-to-tr text-black w-30 mr-6"
@@ -231,7 +230,6 @@ export function ViewContributionHistory(props: {
             />
           </div>
         </div>
-        {/*  */}
         <div className="text-2xl my-6 font-sans">Donation Impact</div>
         <div className="grid grid-cols-2 grid-row-2 lg:grid-cols-3 lg:grid-row-1 gap-6">
           <div className="col-span-2 lg:col-span-1">
@@ -240,10 +238,6 @@ export function ViewContributionHistory(props: {
               value={"$" + totalDonations.toFixed(2).toString()}
             />
           </div>
-          {/* todo: get the matching amount */}
-          {/* <div className="col-span-2 lg:col-span-1">
-            <StatCard title="Total Est. Matching" value={"$" + "56M"} />
-          </div> */}
           <div className="col-span-1">
             <StatCard
               title="Contributions"

--- a/packages/grant-explorer/src/features/contributors/__tests__/ViewContributionHistory.test.tsx
+++ b/packages/grant-explorer/src/features/contributors/__tests__/ViewContributionHistory.test.tsx
@@ -173,7 +173,7 @@ describe("<ViewContributionHistory/>", () => {
     );
 
     expect(screen.getByText("Donation Impact")).toBeInTheDocument();
-    expect(screen.getByText("Total Est. Matching")).toBeInTheDocument();
+    // expect(screen.getByText("Total Est. Matching")).toBeInTheDocument();
     expect(screen.getByText("Donation History")).toBeInTheDocument();
     expect(screen.getByText("Active Rounds")).toBeInTheDocument();
     expect(screen.getByText("Past Rounds")).toBeInTheDocument();

--- a/packages/grant-explorer/src/features/contributors/__tests__/ViewContributionHistory.test.tsx
+++ b/packages/grant-explorer/src/features/contributors/__tests__/ViewContributionHistory.test.tsx
@@ -173,7 +173,6 @@ describe("<ViewContributionHistory/>", () => {
     );
 
     expect(screen.getByText("Donation Impact")).toBeInTheDocument();
-    // expect(screen.getByText("Total Est. Matching")).toBeInTheDocument();
     expect(screen.getByText("Donation History")).toBeInTheDocument();
     expect(screen.getByText("Active Rounds")).toBeInTheDocument();
     expect(screen.getByText("Past Rounds")).toBeInTheDocument();


### PR DESCRIPTION


Fixes: #3307 

## Description

Remove the matching stat card until we fetch that data for the individual cart.

## Checklist

This PR:

- [ ] Does it add new payout or donation token? In this case, have they been added to the indexer to avoid it to crash?
- [ ] Includes only changes relevant to the original ticket. Significant refactoring needs to be separated.
- [ ] Doesn't disable eslint rules.
- [ ] Doesn't work around the type checker (including but not limited to: type casts, non-null assertions, `@ts-ignore`, unjustified optional values).
- [ ] Doesn't contain commented out code.
- [ ] If adding/updating a feature, it adds/updates its test script on Notion.
