### PR TITLE
Fix "View on Explorer" link

### DIFF
--- a/packages/round-manager/src/features/round/ViewRoundPage.tsx
+++ b/packages/round-manager/src/features/round/ViewRoundPage.tsx
@@ -137,7 +137,7 @@ export default function ViewRoundPage() {
                   <ViewGrantsExplorerButton
                     iconStyle="h-4 w-4"
                     chainId={`${chain.id}`}
-                    roundId={id}
+                    roundId={round.id}
                   />
                 </div>
               </div>


### PR DESCRIPTION
The "View on Explorer" link on round manager was using the project id instead of the round id. 
This PR fixes the issue


Fixes: #issue

## Description

<!-- Describe your changes here. -->

## Checklist

This PR:

- [ ] Does it add new payout or donation token? In this case, have they been added to the indexer to avoid it to crash?
- [ ] Includes only changes relevant to the original ticket. Significant refactoring needs to be separated.
- [ ] Doesn't disable eslint rules.
- [ ] Doesn't work around the type checker (including but not limited to: type casts, non-null assertions, `@ts-ignore`, unjustified optional values).
- [ ] Doesn't contain commented out code.
- [ ] If adding/updating a feature, it adds/updates its test script on Notion.
