### PR TITLE
chore: prevent unchecking all chains in checkout

### DIFF
--- a/packages/grant-explorer/src/features/round/ViewCartPage/ChainConfirmationModalBody.tsx
+++ b/packages/grant-explorer/src/features/round/ViewCartPage/ChainConfirmationModalBody.tsx
@@ -36,6 +36,7 @@ export function ChainConfirmationModalBody({
   const getVotingTokenForChain = useCartStorage(
     (state) => state.getVotingTokenForChain
   );
+
   return (
     <>
       <p className="text-sm text-grey-400">
@@ -52,6 +53,7 @@ export function ChainConfirmationModalBody({
               selectedPayoutToken={getVotingTokenForChain(chainId)}
               totalDonation={totalDonationsPerChain[chainId]}
               checked={chainIdsBeingCheckedOut.includes(chainId)}
+              chainsBeingCheckedOut={chainIdsBeingCheckedOut.length}
               onChange={(checked) =>
                 handleChainCheckboxChange(chainId, checked)
               }
@@ -68,6 +70,7 @@ type ChainSummaryProps = {
   selectedPayoutToken: VotingToken;
   chainId: ChainId;
   checked: boolean;
+  chainsBeingCheckedOut: number;
   onChange: (checked: boolean) => void;
   isLastItem: boolean;
 };
@@ -77,9 +80,11 @@ export function ChainSummary({
   totalDonation,
   chainId,
   checked,
+  chainsBeingCheckedOut,
   onChange,
   isLastItem,
 }: ChainSummaryProps) {
+
   return (
     <div
       className={`flex flex-col justify-center mt-2 font-semibold ${
@@ -89,8 +94,11 @@ export function ChainSummary({
       <p>
         <input
           type="checkbox"
-          className="mr-2 rounded-sm"
+          className={`mr-2 rounded-sm  ${
+            chainsBeingCheckedOut === 1 ? "invisible" : ""
+          }`}
           checked={checked}
+          disabled={chainsBeingCheckedOut === 1}
           onChange={(e) => onChange(e.target.checked)}
         />
         <img


### PR DESCRIPTION
fixes #3190

## Description

To Test:

- [ ] Add at least 1 project from 2 different networks to your cart.
- [ ] Continue to checkout and trigger the modal.
- [ ] Unselect one of the networks.

## Checklist

This PR:

- [x] Does it add new payout or donation token? In this case, have they been added to the indexer to avoid it to crash?
- [x] Includes only changes relevant to the original ticket. Significant refactoring needs to be separated.
- [x] Doesn't disable eslint rules.
- [x] Doesn't work around the type checker (including but not limited to: type casts, non-null assertions, `@ts-ignore`, unjustified optional values).
- [x] Doesn't contain commented out code.
- [x] If adding/updating a feature, it adds/updates its test script on Notion.
