### PR TITLE
Make projectstats panel collapse on mobile

### DIFF
--- a/packages/grant-explorer/src/features/round/ViewProjectDetails.tsx
+++ b/packages/grant-explorer/src/features/round/ViewProjectDetails.tsx
@@ -550,7 +550,7 @@ export function ProjectStats() {
     (isInfiniteDate(round.roundEndTime) || round.roundEndTime > new Date());
 
   return (
-    <div className="p-4 gap-4 grid grid-cols-3 md:flex md:flex-col text-blue-800">
+    <div className="rounded-3xl flex-auto p-3 md:p-4 gap-4 flex flex-col text-blue-800">
       <Stat
         isLoading={!application}
         value={`$${application?.totalAmountDonatedInUsd.toFixed(2)}`}


### PR DESCRIPTION
<!-- Thank you for your pull request! Before marking it as "Ready for review",
please ensure that all items of checklist are satisfied and that CI checks are
passing.  -->

Fixes: 
Addresses project stats sidepanel not displaying neatly on mobile/small screens.
![image](https://github.com/gitcoinco/grants-stack/assets/43460021/c2aa09b1-2ce3-48c7-a908-748543755ade)


## Description

Styling fixes that makes the box auto-scale from row to column depending on screen size.
![image](https://github.com/gitcoinco/grants-stack/assets/43460021/4a767ca2-8509-4912-9ae3-a0619926f6b5)

## Checklist

This PR:

- [ ] Does it add new payout or donation token? In this case, have they been added to the indexer to avoid it to crash?
- [x] Includes only changes relevant to the original ticket. Significant refactoring needs to be separated.
- [x] Doesn't disable eslint rules.
- [x] Doesn't work around the type checker (including but not limited to: type casts, non-null assertions, `@ts-ignore`, unjustified optional values).
- [x] Doesn't contain commented out code.
- [ ] If adding/updating a feature, it adds/updates its test script on Notion.
