### PR TITLE
chore: use anchor address of project at the time of applying

### DIFF
--- a/packages/data-layer/src/data-layer.ts
+++ b/packages/data-layer/src/data-layer.ts
@@ -428,6 +428,7 @@ export class DataLayer {
           }
         ) {
           id
+          anchorAddress
           chainId
           roundId
           projectId
@@ -478,7 +479,7 @@ export class DataLayer {
         contributorCount: a.uniqueDonorsCount,
         contributionsTotalUsd: a.totalAmountDonatedInUsd,
         tags: a.round.tags,
-        anchorAddress: a.project.anchorAddress,
+        anchorAddress: a.anchorAddress,
       };
     });
   }

--- a/packages/data-layer/src/data.types.ts
+++ b/packages/data-layer/src/data.types.ts
@@ -705,6 +705,7 @@ export type Application = {
   totalAmountDonatedInUsd: number;
   totalDonationsCount: string;
   uniqueDonorsCount: number;
+  anchorAddress?: string;
   round: {
     strategyName: RoundPayoutType;
     donationsStartTime: string;

--- a/packages/data-layer/src/openapi-search-client/models/ApplicationSummary.ts
+++ b/packages/data-layer/src/openapi-search-client/models/ApplicationSummary.ts
@@ -171,6 +171,7 @@ export function ApplicationSummaryFromJSONTyped(
     createdAtBlock: json["createdAtBlock"],
     contributorCount: json["contributorCount"],
     contributionsTotalUsd: json["contributionsTotalUsd"],
+    anchorAddress: json["anchorAddress"],
   };
 }
 
@@ -199,5 +200,6 @@ export function ApplicationSummaryToJSON(
     createdAtBlock: value.createdAtBlock,
     contributorCount: value.contributorCount,
     contributionsTotalUsd: value.contributionsTotalUsd,
+    anchorAddress: value.anchorAddress,
   };
 }

--- a/packages/data-layer/src/queries.ts
+++ b/packages/data-layer/src/queries.ts
@@ -296,6 +296,7 @@ export const getApplicationsForExplorer = gql`
       totalAmountDonatedInUsd
       uniqueDonorsCount
       totalDonationsCount
+      anchorAddress
       round {
         strategyName
         donationsStartTime

--- a/packages/data-layer/src/queries.ts
+++ b/packages/data-layer/src/queries.ts
@@ -261,6 +261,7 @@ export const getApplication = gql`
       totalAmountDonatedInUsd
       uniqueDonorsCount
       totalDonationsCount
+      anchorAddress
       round {
         strategyName
         donationsStartTime

--- a/packages/grant-explorer/src/features/discovery/ExploreProjectsPage.tsx
+++ b/packages/grant-explorer/src/features/discovery/ExploreProjectsPage.tsx
@@ -197,13 +197,13 @@ export function ExploreProjectsPage(): JSX.Element {
           collection
             ? ""
             : isLoading
-              ? "Loading..."
-              : `${pageTitle} (${totalApplicationsCount})`
+            ? "Loading..."
+            : `${pageTitle} (${totalApplicationsCount})`
         }
         action={
           collection && (
             <div className="font-mono flex gap-x-4">
-              {/* <form
+              <form
                 className="relative"
                 onSubmit={onSearchSubmit}
                 onBlur={onSearchSubmit}
@@ -232,7 +232,7 @@ export function ExploreProjectsPage(): JSX.Element {
                     options={FILTER_OPTIONS}
                   />
                 </div>
-              )} */}
+              )}
             </div>
           )
         }

--- a/packages/grant-explorer/src/features/discovery/LandingTabs.tsx
+++ b/packages/grant-explorer/src/features/discovery/LandingTabs.tsx
@@ -37,12 +37,12 @@ export default function LandingTabs() {
       children: isDesktop ? "Explore rounds" : "Rounds",
       tabName: "home-rounds-tab",
     },
-    // {
-    //   to: "/projects",
-    //   activeRegExp: /^\/projects/,
-    //   children: isDesktop ? "Explore projects" : "Projects",
-    //   tabName: "home-projects-tab",
-    // },
+    {
+      to: "/projects",
+      activeRegExp: /^\/projects/,
+      children: isDesktop ? "Explore projects" : "Projects",
+      tabName: "home-projects-tab",
+    },
   ];
 
   return (

--- a/packages/grant-explorer/src/features/projects/hooks/useApplication.ts
+++ b/packages/grant-explorer/src/features/projects/hooks/useApplication.ts
@@ -30,7 +30,7 @@ export function mapApplicationToProject(application: Application): Project {
     projectMetadata: application.project.metadata,
     status: application.status,
     grantApplicationFormAnswers: application.metadata.application.answers ?? [],
-    anchorAddress: application.project.anchorAddress,
+    anchorAddress: application.anchorAddress,
   };
 }
 


### PR DESCRIPTION
instead of the latest anchor address

Currently, we rely on the anchor address from the project itself. The issue here is that if a project changes it's name, the anchor address changes, which means the new recipient Id is not accounted for on the pool strategy.
This change ensures we use the anchor used at the time of the applying and not the latest anchor address

![Deploy](https://github.com/gitcoinco/grants-stack/assets/5358146/241017e9-6ea2-489c-bf81-44eff9a189c7)