### PR TITLE
disable explore project on v1

### DIFF
--- a/packages/grant-explorer/src/features/discovery/LandingTabs.tsx
+++ b/packages/grant-explorer/src/features/discovery/LandingTabs.tsx
@@ -3,6 +3,9 @@ import { Tab, Tabs } from "../common/styles";
 import { toQueryString } from "./RoundsFilter";
 import { RoundStatus } from "./hooks/useFilterRounds";
 import { useMediaQuery } from "@chakra-ui/react";
+import {
+  useAlloVersion,
+} from "common/src/components/AlloVersionSwitcher";
 
 type TabType = {
   to: string;
@@ -44,6 +47,12 @@ export default function LandingTabs() {
       tabName: "home-projects-tab",
     },
   ];
+
+  const { version: currentVersion } = useAlloVersion();
+  if (currentVersion === "allo-v1") {
+    // Remove the projects tab if the current version is allo-v1
+    tabs.pop();
+  }
 
   return (
     <Tabs className="font-mono">


### PR DESCRIPTION

#### Description

https://discord.com/channels/562828676480237578/1233348739721199687/1233412176199421993.

Project explore tab loads projects only for allo-v2. 
Hence it makes sense for this tab to be removed 
