### PR TITLE
Fix program filter

### DIFF
--- a/packages/round-manager/src/features/api/program.ts
+++ b/packages/round-manager/src/features/api/program.ts
@@ -56,10 +56,7 @@ export async function listPrograms(
     // Filter out programs where operatorWallets does not include round.createdByAddress.
     // This is to filter out spam rounds created by bots
     programs = programs.filter((program) => {
-      return (
-        program.createdByAddress &&
-        program.operatorWallets?.includes(program.createdByAddress)
-      );
+      return program.operatorWallets?.includes(address);
     });
 
     return programs;

--- a/packages/round-manager/src/features/api/program.ts
+++ b/packages/round-manager/src/features/api/program.ts
@@ -34,30 +34,29 @@ export async function listPrograms(
       throw Error("Unable to fetch programs");
     }
 
-    let programs: Program[] = [];
+    const programs: Program[] = [];
 
     for (const program of programsRes.programs) {
-      programs.push({
-        id: program.id,
-        metadata: program.metadata,
-        operatorWallets: program.roles.map(
-          (role: { address: string }) => role.address
-        ),
-        tags: program.tags,
-        chain: {
-          id: chainId,
-          name: CHAINS[chainId]?.name,
-          logo: CHAINS[chainId]?.logo,
-        },
-        createdByAddress: program.createdByAddress,
-      });
+      if (
+        program.roles.some(
+          (role) => role.role === "OWNER" && role.address === address
+        )
+      )
+        programs.push({
+          id: program.id,
+          metadata: program.metadata,
+          operatorWallets: program.roles.map(
+            (role: { address: string }) => role.address
+          ),
+          tags: program.tags,
+          chain: {
+            id: chainId,
+            name: CHAINS[chainId]?.name,
+            logo: CHAINS[chainId]?.logo,
+          },
+          createdByAddress: program.createdByAddress,
+        });
     }
-
-    // Filter out programs where operatorWallets does not include round.createdByAddress.
-    // This is to filter out spam rounds created by bots
-    programs = programs.filter((program) => {
-      return program.operatorWallets?.includes(address);
-    });
 
     return programs;
   } catch (error) {


### PR DESCRIPTION
Context: https://discord.com/channels/562828676480237578/1234146304108531852

If the creator is the EOA, but the operator is the Safe and this will never return true. The newly introduced change filters the programs by Owner address


Fixes: #issue

## Description

<!-- Describe your changes here. -->

## Checklist

This PR:

- [ ] Does it add new payout or donation token? In this case, have they been added to the indexer to avoid it to crash?
- [ ] Includes only changes relevant to the original ticket. Significant refactoring needs to be separated.
- [ ] Doesn't disable eslint rules.
- [ ] Doesn't work around the type checker (including but not limited to: type casts, non-null assertions, `@ts-ignore`, unjustified optional values).
- [ ] Doesn't contain commented out code.
- [ ] If adding/updating a feature, it adds/updates its test script on Notion.
