### PR TITLE
rm: lit is optional

### DIFF
--- a/packages/builder/src/actions/roundApplication.ts
+++ b/packages/builder/src/actions/roundApplication.ts
@@ -134,7 +134,7 @@ const dispatchAndLogApplicationError = (
   dispatch(applicationError(roundAddress, error, step));
 };
 
-export function chainIdToChainName(chainId: number): string {
+export function chainIdToChainName(chainId: number): string | undefined {
   // eslint-disable-next-line no-restricted-syntax
   for (const name in LitJsSdk.LIT_CHAINS) {
     if (LitJsSdk.LIT_CHAINS[name].chainId === chainId) {
@@ -142,7 +142,8 @@ export function chainIdToChainName(chainId: number): string {
     }
   }
 
-  throw new Error(`couldn't find LIT chain name for chainId ${chainId}`);
+  return undefined;
+  // throw new Error(`couldn't find LIT chain name for chainId ${chainId}`);
 }
 
 const applyToRound =

--- a/packages/builder/src/utils/RoundApplicationBuilder.ts
+++ b/packages/builder/src/utils/RoundApplicationBuilder.ts
@@ -14,31 +14,34 @@ export default class RoundApplicationBuilder {
 
   private roundAddress: string;
 
-  private chainName: string;
-
-  private lit: Lit;
+  private lit?: Lit;
 
   constructor(
     enableEncryption: boolean,
     project: Project,
     ram: RoundApplicationMetadata,
     roundAddress: string,
-    chainName: string
+    chainName?: string
   ) {
     this.enableEncryption = enableEncryption;
     this.project = project;
     this.ram = ram;
     this.roundAddress = roundAddress;
-    this.chainName = chainName;
-    const litInit = {
-      chain: chainName,
-      contract: this.roundAddress,
-    };
 
-    this.lit = new Lit(litInit);
+    if (chainName) {
+      const litInit = {
+        chain: chainName,
+        contract: this.roundAddress,
+      };
+      this.lit = new Lit(litInit);
+    }
   }
 
   async encryptAnswer(answer: string) {
+    if (!this.lit) {
+      throw new Error("lit not initialized");
+    }
+
     if (!this.enableEncryption) {
       return {
         ciphertext: answer,

--- a/packages/common/src/allo/backends/allo-v2.ts
+++ b/packages/common/src/allo/backends/allo-v2.ts
@@ -495,7 +495,9 @@ export class AlloV2 implements Allo {
         token,
         amount: 0n, // we send 0 tokens to the pool, we fund it later
         metadata: { protocol: 1n, pointer: roundIpfsResult.value },
-        managers: args.roundData.roundOperators ?? [],
+        managers: (args.roundData.roundOperators ?? []).map((operator) =>
+          getAddress(operator)
+        ),
       };
 
       const txData = this.allo.createPool(createPoolArgs);

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -496,3 +496,9 @@ export function isChainIdSupported(chainId: number) {
   }
   return Object.values(ChainId).includes(chainId);
 }
+
+export function isLitUnavailable(chainId: number) {
+  return [
+    ChainId.SEPOLIA
+  ].includes(chainId);
+}

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -499,6 +499,10 @@ export function isChainIdSupported(chainId: number) {
 
 export function isLitUnavailable(chainId: number) {
   return [
-    ChainId.SEPOLIA
+    ChainId.LUKSO_TESTNET,
+    ChainId.LUKSO,
+    ChainId.CELO,
+    ChainId.CELO_ALFAJORES,
+    ChainId.SEI_DEVNET,
   ].includes(chainId);
 }

--- a/packages/round-manager/src/app/wagmi.ts
+++ b/packages/round-manager/src/app/wagmi.ts
@@ -31,6 +31,10 @@ import {
   zkSyncEraTestnet,
   sepolia,
   seiDevnet,
+  customLukso as lukso,
+  customLuksoTestnet as luksoTestnet,
+  customCelo as celo,
+  customCeloAlfajores as celoAlfajores,
 } from "common/src/chains";
 import { publicProvider } from "wagmi/providers/public";
 import { infuraProvider } from "wagmi/providers/infura";
@@ -46,6 +50,8 @@ const testnetChains = () => {
     avalancheFuji,
     sepolia,
     seiDevnet,
+    luksoTestnet,
+    celoAlfajores,
   ];
 };
 
@@ -62,6 +68,8 @@ const mainnetChains = () => {
     scroll,
     { ...fantom, iconUrl: "/logos/fantom-logo.svg" },
     seiDevnet,
+    lukso,
+    celo,
   ];
 };
 

--- a/packages/round-manager/src/features/common/AddQuestionModal.tsx
+++ b/packages/round-manager/src/features/common/AddQuestionModal.tsx
@@ -8,6 +8,8 @@ import { SchemaQuestion, typeToText } from "../api/utils";
 import BaseSwitch from "./BaseSwitch";
 import { InputIcon } from "./InputIcon";
 import Option from "./Option";
+import { useWallet } from "./Auth";
+import { isLitUnavailable } from "common";
 
 const INITIAL_VALUE = "Select a type";
 
@@ -37,6 +39,8 @@ function AddQuestionModal({
   onClose,
 }: AddQuestionModalProps) {
   const questionExists = question && question.index !== undefined;
+
+  const { chain } = useWallet();
 
   const [isOpen, setIsOpen] = useState(show);
   const initialQuestion = question;
@@ -82,6 +86,7 @@ function AddQuestionModal({
         <BaseSwitch
           testid="encrypted-toggle"
           key="encrypted"
+          disabled={isLitUnavailable(chain.id)}
           activeLabel="Encrypted"
           inactiveLabel="Not Encrypted"
           value={

--- a/packages/round-manager/src/features/common/BaseSwitch.tsx
+++ b/packages/round-manager/src/features/common/BaseSwitch.tsx
@@ -17,12 +17,14 @@ const BaseSwitch = ({
   value,
   handler,
   testid,
+  disabled=false
 }: {
   activeLabel: string;
   inactiveLabel: string;
   value: boolean;
   handler: (a: boolean) => void;
   testid: string;
+  disabled?: boolean;
 }) => (
   <Switch.Group
     as="div"
@@ -46,6 +48,7 @@ const BaseSwitch = ({
       </Switch.Label>
     </span>
     <Switch
+      disabled={disabled}
       data-testid={testid}
       className="focus:outline-0! bg-gray-200 relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out"
       onChange={handler}

--- a/packages/round-manager/src/features/common/BaseSwitch.tsx
+++ b/packages/round-manager/src/features/common/BaseSwitch.tsx
@@ -17,7 +17,7 @@ const BaseSwitch = ({
   value,
   handler,
   testid,
-  disabled=false
+  disabled = false,
 }: {
   activeLabel: string;
   inactiveLabel: string;
@@ -28,7 +28,9 @@ const BaseSwitch = ({
 }) => (
   <Switch.Group
     as="div"
-    className={classNames("flex items-center justify-end")}
+    className={classNames(
+      `flex items-center justify-end ${disabled ? "opacity-50" : ""}`
+    )}
   >
     <span className="flex-grow">
       <Switch.Label

--- a/packages/round-manager/src/features/round/RoundApplicationForm.tsx
+++ b/packages/round-manager/src/features/round/RoundApplicationForm.tsx
@@ -6,7 +6,7 @@ import {
   LockOpenIcon,
 } from "@heroicons/react/outline";
 import { PencilIcon, PlusSmIcon, XIcon } from "@heroicons/react/solid";
-import { useAllo } from "common";
+import { isLitUnavailable, useAllo } from "common";
 import { Button } from "common/src/styles";
 import { RoundCategory } from "data-layer";
 import _ from "lodash";
@@ -44,7 +44,7 @@ import { InputIcon } from "../common/InputIcon";
 import PreviewQuestionModal from "../common/PreviewQuestionModal";
 import ProgressModal from "../common/ProgressModal";
 
-export const initialQuestionsQF: SchemaQuestion[] = [
+export const getInitialQuestionsQF = (chainId: number) => [
   {
     id: 0,
     title: "Payout Wallet Address",
@@ -59,7 +59,7 @@ export const initialQuestionsQF: SchemaQuestion[] = [
     id: 1,
     title: "Email Address",
     required: true,
-    encrypted: true,
+    encrypted: !isLitUnavailable(chainId),
     hidden: true,
     type: "email",
   },
@@ -81,12 +81,12 @@ export const initialQuestionsQF: SchemaQuestion[] = [
   },
 ];
 
-export const initialQuestionsDirect: SchemaQuestion[] = [
+export const getInitialQuestionsDirect = (chainId: number) => [
   {
     id: 1,
     title: "Email Address",
     required: true,
-    encrypted: true,
+    encrypted: !isLitUnavailable(chainId),
     hidden: true,
     type: "email",
     fixed: true,
@@ -185,7 +185,7 @@ export function RoundApplicationForm(props: {
   const [openPreviewModal, setOpenPreviewModal] = useState(false);
   const [openAddQuestionModal, setOpenAddQuestionModal] = useState(false);
   const [toEdit, setToEdit] = useState<EditQuestion | undefined>();
-  const { signer: walletSigner } = useWallet();
+  const { signer: walletSigner, chain } = useWallet();
 
   const { currentStep, setCurrentStep, stepsCount, formData } =
     useContext(FormContext);
@@ -206,8 +206,8 @@ export function RoundApplicationForm(props: {
   const defaultQuestions: ApplicationMetadata["questions"] = questionsArg
     ? questionsArg
     : roundCategory === RoundCategory.QuadraticFunding
-    ? initialQuestionsQF
-    : initialQuestionsDirect;
+    ? getInitialQuestionsQF(chain.id)
+    : getInitialQuestionsDirect(chain.id);
 
   const { control, handleSubmit } = useForm<Round>({
     defaultValues: {


### PR DESCRIPTION
This PR adds a util function where we can specify where LIT is not supported. If you attempt to create a round on unsupported LIT chain, then encryption options is disabled and email is defaulted to non-encrypted

**Round:**
http://localhost:3000/#/round/132

**Builder**
http://localhost:3001/#/chains/11155111/rounds/132/apply
http://localhost:3001/#/chains/11155111/registry/0x/projects/0x663a65b17790c882b4606a423641381db8cbb692f35869344bc35b172c36f364

**View Email Without Encrypted Data**
http://localhost:3000/#/round/132/application/0?debug=true