### PR TITLE
 Remove zk sepolia test token

### DIFF
--- a/packages/grant-explorer/src/features/api/utils.ts
+++ b/packages/grant-explorer/src/features/api/utils.ts
@@ -363,16 +363,6 @@ const ZKSYNC_ERA_TESTNET_TOKENS: VotingToken[] = [
     defaultForVoting: true,
     canVote: true,
   },
-  {
-    name: "TEST",
-    chainId: ChainId.ZKSYNC_ERA_TESTNET_CHAIN_ID,
-    address: "0x8fd03Cd97Da068CC242Ab7551Dc4100DD405E8c7",
-    decimal: 18,
-    logo: TokenNamesAndLogos["DAI"],
-    redstoneTokenId: RedstoneTokenIds["DAI"],
-    defaultForVoting: false,
-    canVote: true,
-  },
 ];
 
 const ZKSYNC_ERA_MAINNET_TOKENS: VotingToken[] = [

--- a/packages/round-manager/src/features/api/payoutTokens.ts
+++ b/packages/round-manager/src/features/api/payoutTokens.ts
@@ -192,14 +192,6 @@ const ZKSYNC_ERA_TESTNET_TOKENS: PayoutToken[] = [
     logo: TokenNamesAndLogos["ETH"],
     redstoneTokenId: RedstoneTokenIds["ETH"],
   },
-  {
-    name: "TEST",
-    chainId: ChainId.ZKSYNC_ERA_TESTNET_CHAIN_ID,
-    address: "0x8fd03Cd97Da068CC242Ab7551Dc4100DD405E8c7",
-    decimal: 18,
-    logo: TokenNamesAndLogos["DAI"],
-    redstoneTokenId: RedstoneTokenIds["DAI"],
-  },
 ];
 
 const ZKSYNC_ERA_MAINNET_TOKENS: PayoutToken[] = [


### PR DESCRIPTION


## Description

Removes the zk Sepolia TEST token to prevent it from being used.

## Checklist

This PR:

- [ ] Does it add new payout or donation token? In this case, have they been added to the indexer to avoid it to crash?
- [ ] Includes only changes relevant to the original ticket. Significant refactoring needs to be separated.
- [ ] Doesn't disable eslint rules.
- [ ] Doesn't work around the type checker (including but not limited to: type casts, non-null assertions, `@ts-ignore`, unjustified optional values).
- [ ] Doesn't contain commented out code.
- [ ] If adding/updating a feature, it adds/updates its test script on Notion.
