### PR TITLE
add a Manage Team section to Round Details page

### DIFF
--- a/packages/round-manager/src/features/api/round.ts
+++ b/packages/round-manager/src/features/api/round.ts
@@ -128,6 +128,7 @@ function indexerV2RoundToRound(round: RoundForManager): Round {
     },
     ownedBy: round.projectId,
     operatorWallets: operatorWallets,
+    roles: round.roles,
     finalized: false,
     tags: round.tags,
     createdByAddress: round.createdByAddress,

--- a/packages/round-manager/src/features/api/types.ts
+++ b/packages/round-manager/src/features/api/types.ts
@@ -8,7 +8,7 @@ import { RoundVisibilityType } from "common";
 import { BigNumber } from "ethers";
 import { Address } from "viem";
 import { SchemaQuestion } from "./utils";
-import { RoundForManager, SybilDefense } from "data-layer";
+import { AddressAndRole, RoundForManager, SybilDefense } from "data-layer";
 
 export type Network = "optimism" | "fantom" | "pgn";
 
@@ -239,6 +239,10 @@ export interface Round {
    * Addresses of wallets that will have admin privileges to operate the Grant program
    */
   operatorWallets?: Array<string>;
+  /**
+   * List of addresses and their roles in the round
+   */
+  roles?: AddressAndRole[];
   /**
    * List of projects approved for the round
    */

--- a/packages/round-manager/src/features/round/ViewManageTeam.tsx
+++ b/packages/round-manager/src/features/round/ViewManageTeam.tsx
@@ -1,7 +1,15 @@
 export default function ViewManageTeam() {
   return (
     <div>
-      <h4>Manage Team</h4>
+      <p className="font-bold text-lg mt-2 mb-2">Manage Team</p>
+      <p className="text-sm text-gray-400 mb-2">
+        Add or remove admins and operators to your team.{" "}
+      </p>
+      <p className="text-sm text-gray-400 mb-2">
+        Make sure to have at least two admins at all times for security
+        purposes.
+      </p>
+      <p className="text-md mt-6 mb-2">View Members</p>
     </div>
   );
 }

--- a/packages/round-manager/src/features/round/ViewManageTeam.tsx
+++ b/packages/round-manager/src/features/round/ViewManageTeam.tsx
@@ -1,4 +1,20 @@
-export default function ViewManageTeam() {
+import { AddressAndRole } from "data-layer";
+import { Round } from "../api/types";
+import { useMemo } from "react";
+
+const sortDataByRole = (data: AddressAndRole[]): AddressAndRole[] => {
+  return data.sort((a, b) => {
+    if (a.role === "ADMIN") return -1;
+    if (b.role === "ADMIN") return 1;
+    return a.role.localeCompare(b.role);
+  });
+};
+
+export default function ViewManageTeam(props: { round: Round | undefined }) {
+  const sortedRoles = useMemo(() => {
+    return sortDataByRole(props.round?.roles || []);
+  }, [props.round?.roles]);
+
   return (
     <div>
       <p className="font-bold text-lg mt-2 mb-2">Manage Team</p>
@@ -9,7 +25,48 @@ export default function ViewManageTeam() {
         Make sure to have at least two admins at all times for security
         purposes.
       </p>
-      <p className="text-md mt-6 mb-2">View Members</p>
+      <p className="text-md mt-6 mb-4">View Members</p>
+      <div className="overflow-x-auto">
+        <table className="min-w-full">
+          <thead>
+            <tr>
+              <th
+                scope="col"
+                className="w-1/4 px-6 py-3 text-left text-base font-medium text-gray-500 tracking-wider"
+              >
+                Name
+              </th>
+              <th
+                scope="col"
+                className="w-2/3 px-6 py-3 text-left text-base font-medium text-gray-500 tracking-wider"
+              >
+                Wallet address
+              </th>
+              <th
+                scope="col"
+                className="w-1/4 px-6 py-3 text-left text-base font-medium text-gray-500 tracking-wider"
+              >
+                Role
+              </th>
+            </tr>
+          </thead>
+          <tbody className="bg-white divide-y divide-gray-100">
+            {sortedRoles.map((item: AddressAndRole, index) => (
+              <tr key={index}>
+                <td className="w-1/4 px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-400">
+                  User
+                </td>
+                <td className="w-2/4 px-6 py-4 whitespace-nowrap text-sm text-gray-400">
+                  {item.address}
+                </td>
+                <td className="w-1/4 px-6 py-4 whitespace-nowrap text-sm text-gray-400">
+                  {item.role === "ADMIN" ? "Admin" : "Operator"}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
     </div>
   );
 }

--- a/packages/round-manager/src/features/round/ViewManageTeam.tsx
+++ b/packages/round-manager/src/features/round/ViewManageTeam.tsx
@@ -1,0 +1,7 @@
+export default function ViewManageTeam() {
+  return (
+    <div>
+      <h4>Manage Team</h4>
+    </div>
+  );
+}

--- a/packages/round-manager/src/features/round/ViewManageTeam.tsx
+++ b/packages/round-manager/src/features/round/ViewManageTeam.tsx
@@ -32,7 +32,7 @@ export default function ViewManageTeam(props: { round: Round | undefined }) {
             <tr>
               <th
                 scope="col"
-                className="w-1/4 px-6 py-3 text-left text-base font-medium text-gray-500 tracking-wider"
+                className="w-1/4 py-3 text-left text-base font-medium text-gray-500 tracking-wider"
               >
                 Name
               </th>
@@ -53,7 +53,7 @@ export default function ViewManageTeam(props: { round: Round | undefined }) {
           <tbody className="bg-white divide-y divide-gray-100">
             {sortedRoles.map((item: AddressAndRole, index) => (
               <tr key={index}>
-                <td className="w-1/4 px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-400">
+                <td className="w-1/4 py-4 whitespace-nowrap text-sm font-medium text-gray-400">
                   User
                 </td>
                 <td className="w-2/4 px-6 py-4 whitespace-nowrap text-sm text-gray-400">

--- a/packages/round-manager/src/features/round/ViewManageTeam.tsx
+++ b/packages/round-manager/src/features/round/ViewManageTeam.tsx
@@ -1,6 +1,7 @@
 import { AddressAndRole } from "data-layer";
 import { Round } from "../api/types";
 import { useMemo } from "react";
+import { useEnsName } from "wagmi";
 
 const sortDataByRole = (data: AddressAndRole[]): AddressAndRole[] => {
   return data.sort((a, b) => {
@@ -18,12 +19,9 @@ export default function ViewManageTeam(props: { round: Round | undefined }) {
   return (
     <div>
       <p className="font-bold text-lg mt-2 mb-2">Manage Team</p>
+      <p className="text-sm text-gray-400 mb-2">View who is on your team.</p>
       <p className="text-sm text-gray-400 mb-2">
-        Add or remove admins and operators to your team.{" "}
-      </p>
-      <p className="text-sm text-gray-400 mb-2">
-        Make sure to have at least two admins at all times for security
-        purposes.
+        Only admins can add others to your team.
       </p>
       <p className="text-md mt-6 mb-4">View Members</p>
       <div className="overflow-x-auto">
@@ -54,11 +52,9 @@ export default function ViewManageTeam(props: { round: Round | undefined }) {
             {sortedRoles.map((item: AddressAndRole, index) => (
               <tr key={index}>
                 <td className="w-1/4 py-4 whitespace-nowrap text-sm font-medium text-gray-400">
-                  User
+                  User{index + 1}
                 </td>
-                <td className="w-2/4 px-6 py-4 whitespace-nowrap text-sm text-gray-400">
-                  {item.address}
-                </td>
+                <AddressRow address={item.address} />
                 <td className="w-1/4 px-6 py-4 whitespace-nowrap text-sm text-gray-400">
                   {item.role === "ADMIN" ? "Admin" : "Operator"}
                 </td>
@@ -68,5 +64,19 @@ export default function ViewManageTeam(props: { round: Round | undefined }) {
         </table>
       </div>
     </div>
+  );
+}
+
+function AddressRow(props: { address: string }) {
+  const { data: ensName } = useEnsName({
+    address: props.address as `0x${string}`,
+    chainId: 1,
+  });
+  console.log("ensName", ensName);
+
+  return (
+    <td className="w-2/4 px-6 py-4 whitespace-nowrap text-sm text-gray-400">
+      {ensName || props.address}
+    </td>
   );
 }

--- a/packages/round-manager/src/features/round/ViewManageTeam.tsx
+++ b/packages/round-manager/src/features/round/ViewManageTeam.tsx
@@ -72,7 +72,6 @@ function AddressRow(props: { address: string }) {
     address: props.address as `0x${string}`,
     chainId: 1,
   });
-  console.log("ensName", ensName);
 
   return (
     <td className="w-2/4 px-6 py-4 whitespace-nowrap text-sm text-gray-400">

--- a/packages/round-manager/src/features/round/ViewManageTeam.tsx
+++ b/packages/round-manager/src/features/round/ViewManageTeam.tsx
@@ -11,10 +11,37 @@ const sortDataByRole = (data: AddressAndRole[]): AddressAndRole[] => {
   });
 };
 
+const filterRoles = (data: AddressAndRole[]): AddressAndRole[] => {
+  return data.reduce((acc: AddressAndRole[], current) => {
+    const existingIndex = acc.findIndex(
+      (item) => item.address === current.address
+    );
+
+    // Check if this address is already included
+    if (existingIndex === -1) {
+      // If not included, simply add the current item
+      acc.push(current);
+    } else if (
+      acc[existingIndex].role !== "ADMIN" &&
+      current.role === "ADMIN"
+    ) {
+      // If the existing item is not an Admin but the current is, replace it
+      acc[existingIndex] = current;
+    }
+    return acc;
+  }, []);
+};
+
 export default function ViewManageTeam(props: { round: Round | undefined }) {
+  // Show Admin role first, then Operator
   const sortedRoles = useMemo(() => {
     return sortDataByRole(props.round?.roles || []);
   }, [props.round?.roles]);
+
+  // If an address is an Admin & Operator, only show Admin in the UI
+  const filteredRoles = useMemo(() => {
+    return filterRoles(sortedRoles);
+  }, [sortedRoles]);
 
   return (
     <div>
@@ -49,7 +76,7 @@ export default function ViewManageTeam(props: { round: Round | undefined }) {
             </tr>
           </thead>
           <tbody className="bg-white divide-y divide-gray-100">
-            {sortedRoles.map((item: AddressAndRole, index) => (
+            {filteredRoles.map((item: AddressAndRole, index) => (
               <tr key={index}>
                 <td className="w-1/4 py-4 whitespace-nowrap text-sm font-medium text-gray-400">
                   User{index + 1}

--- a/packages/round-manager/src/features/round/ViewRoundPage.tsx
+++ b/packages/round-manager/src/features/round/ViewRoundPage.tsx
@@ -11,6 +11,7 @@ import {
   DocumentTextIcon,
   InboxIcon,
   UserGroupIcon,
+  UserAddIcon,
 } from "@heroicons/react/solid";
 import { Button } from "common/src/styles";
 import { Link, useParams } from "react-router-dom";
@@ -52,6 +53,7 @@ import { getRoundStrategyType } from "common";
 import { useApplicationsByRoundId } from "../common/useApplicationsByRoundId";
 import AlloV1 from "common/src/icons/AlloV1";
 import AlloV2 from "common/src/icons/AlloV2";
+import ViewManageTeam from "./ViewManageTeam";
 
 export const isDirectRound = (round: Round | undefined) => {
   return (
@@ -221,6 +223,29 @@ export default function ViewRoundPage() {
                           </div>
                         )}
                       </Tab>
+                      <Tab
+                        className={({ selected }) =>
+                          verticalTabStyles(selected)
+                        }
+                      >
+                        {({ selected }) => (
+                          <div
+                            className={
+                              selected
+                                ? "text-black-500 flex flex-row"
+                                : "flex flex-row"
+                            }
+                          >
+                            <UserAddIcon className="h-6 w-6 mr-2" />
+                            <span
+                              className="mt-0.5"
+                              data-testid="grant-applications"
+                            >
+                              Manage Team
+                            </span>
+                          </div>
+                        )}
+                      </Tab>
                       {!isDirectRound(round) && (
                         <Tab
                           className={({ selected }) =>
@@ -339,6 +364,9 @@ export default function ViewRoundPage() {
                     )}
                     <Tab.Panel>
                       <ViewRoundSettings id={round?.id} />
+                    </Tab.Panel>
+                    <Tab.Panel>
+                      <ViewManageTeam />
                     </Tab.Panel>
                     {!isDirectRound(round) && (
                       <>

--- a/packages/round-manager/src/features/round/ViewRoundPage.tsx
+++ b/packages/round-manager/src/features/round/ViewRoundPage.tsx
@@ -366,7 +366,7 @@ export default function ViewRoundPage() {
                       <ViewRoundSettings id={round?.id} />
                     </Tab.Panel>
                     <Tab.Panel>
-                      <ViewManageTeam />
+                      <ViewManageTeam round={round} />
                     </Tab.Panel>
                     {!isDirectRound(round) && (
                       <>

--- a/packages/round-manager/src/features/round/__tests__/ViewRoundPage.test.tsx
+++ b/packages/round-manager/src/features/round/__tests__/ViewRoundPage.test.tsx
@@ -30,7 +30,7 @@ jest.mock("@rainbow-me/rainbowkit", () => ({
 jest.mock("data-layer", () => ({
   ...jest.requireActual("data-layer"),
   useDataLayer: () => ({
-   getRoundById: jest.fn(),
+    getRoundById: jest.fn(),
   }),
 }));
 
@@ -173,6 +173,7 @@ describe("View Round", () => {
     expect(screen.getByText("Fund Round")).toBeInTheDocument();
     expect(screen.getByText("Grant Applications")).toBeInTheDocument();
     expect(screen.getByText("Round Settings")).toBeInTheDocument();
+    expect(screen.getByText("Manage Team")).toBeInTheDocument();
     expect(screen.getByText("Round Stats")).toBeInTheDocument();
     expect(screen.getByText("Round Results")).toBeInTheDocument();
     expect(screen.getByText("Fund Grantees")).toBeInTheDocument();
@@ -200,6 +201,7 @@ describe("View Round", () => {
     expect(screen.getByTestId("side-nav-bar")).toBeInTheDocument();
     expect(screen.getByText("Grant Applications")).toBeInTheDocument();
     expect(screen.getByText("Round Settings")).toBeInTheDocument();
+    expect(screen.getByText("Manage Team")).toBeInTheDocument();
     expect(screen.queryAllByText("Fund Contract").length).toBe(0);
     expect(screen.queryAllByText("Round Stats").length).toBe(0);
     expect(screen.queryAllByText("Round Results").length).toBe(0);


### PR DESCRIPTION
<!-- Thank you for your pull request! Before marking it as "Ready for review",
please ensure that all items of checklist are satisfied and that CI checks are
passing.  -->

Fixes: #2727 
Fixes: #2733 

## Description

1. Add a "Manage Team" section to Round Details page on Manager
2. View team members as an operator

## Checklist

This PR:

- [ ] Does it add new payout or donation token? In this case, have they been added to the indexer to avoid it to crash?
- [ ] Includes only changes relevant to the original ticket. Significant refactoring needs to be separated.
- [ ] Doesn't disable eslint rules.
- [ ] Doesn't work around the type checker (including but not limited to: type casts, non-null assertions, `@ts-ignore`, unjustified optional values).
- [ ] Doesn't contain commented out code.
- [ ] If adding/updating a feature, it adds/updates its test script on Notion.
