### PR TITLE
DG: Add payout token list

### DIFF
--- a/packages/round-manager/src/features/round/ApplicationDirectPayout.tsx
+++ b/packages/round-manager/src/features/round/ApplicationDirectPayout.tsx
@@ -128,7 +128,7 @@ export default function ApplicationDirectPayout({ round, application }: Props) {
 
       if (selectedTokenInfo) {
         setSelectedToken(selectedTokenInfo.address);
-        setTokenInfo(selectedTokenInfo); // Assuming setTokenInfo is a function to update tokenInfo
+        setTokenInfo(selectedTokenInfo);
       }
     }
   };

--- a/packages/round-manager/src/features/round/ApplicationDirectPayout.tsx
+++ b/packages/round-manager/src/features/round/ApplicationDirectPayout.tsx
@@ -281,7 +281,7 @@ export default function ApplicationDirectPayout({ round, application }: Props) {
         for (const payout of filteredPayouts) {
           const token = map.get(payout.tokenAddress.toLowerCase());
           if (!token) {
-            const token = payoutTokens.find(
+            const pToken = payoutTokens.find(
               (p) =>
                 p.address.toLowerCase() === payout.tokenAddress.toLowerCase()
             );
@@ -289,14 +289,14 @@ export default function ApplicationDirectPayout({ round, application }: Props) {
             let decimal = 0;
             let name = "";
 
-            if (!token) {
+            if (!pToken) {
               // Token not found in the list, fetch from contract
               const tokenData = await fetchTokenData(payout.tokenAddress);
               decimal = tokenData.decimal;
               name = tokenData.name;
             } else {
-              decimal = token.decimal;
-              name = token.name;
+              decimal = pToken.decimal;
+              name = pToken.name;
             }
 
             map.set(payout.tokenAddress.toLowerCase(), {

--- a/packages/round-manager/src/features/round/ApplicationDirectPayout.tsx
+++ b/packages/round-manager/src/features/round/ApplicationDirectPayout.tsx
@@ -117,7 +117,6 @@ export default function ApplicationDirectPayout({ round, application }: Props) {
 
   const handleTokenChange = (event: ChangeEvent<HTMLSelectElement>) => {
     if (event.target.value === "custom") {
-      // fetch symbol and decimals
       setSelectedToken("custom");
       setTokenInfo({ ...noToken(), name: "custom" });
     } else {

--- a/packages/round-manager/src/features/round/RoundApplicationForm.tsx
+++ b/packages/round-manager/src/features/round/RoundApplicationForm.tsx
@@ -111,16 +111,6 @@ export const getInitialQuestionsDirect = (chainId: number) => [
   },
   {
     id: 4,
-    title: "Payout token",
-    required: true,
-    encrypted: false,
-    hidden: true,
-    type: "dropdown",
-    choices: ["DAI"], // ETH is not supported.
-    fixed: false,
-  },
-  {
-    id: 5,
     title: "Payout wallet address",
     required: true,
     encrypted: false,
@@ -130,7 +120,7 @@ export const getInitialQuestionsDirect = (chainId: number) => [
     metadataExcluded: true,
   },
   {
-    id: 6,
+    id: 5,
     title: "Milestones",
     required: true,
     encrypted: false,
@@ -138,7 +128,7 @@ export const getInitialQuestionsDirect = (chainId: number) => [
     type: "paragraph",
   },
   {
-    id: 7,
+    id: 6,
     title: "Funding Sources",
     required: true,
     encrypted: false,
@@ -146,7 +136,7 @@ export const getInitialQuestionsDirect = (chainId: number) => [
     type: "short-answer",
   },
   {
-    id: 8,
+    id: 7,
     title: "Team Size",
     required: true,
     encrypted: false,

--- a/packages/round-manager/src/features/round/RoundApplicationForm.tsx
+++ b/packages/round-manager/src/features/round/RoundApplicationForm.tsx
@@ -102,15 +102,6 @@ export const getInitialQuestionsDirect = (chainId: number) => [
   },
   {
     id: 3,
-    title: "Amount requested",
-    required: true,
-    encrypted: false,
-    hidden: true,
-    type: "number",
-    fixed: false,
-  },
-  {
-    id: 4,
     title: "Payout wallet address",
     required: true,
     encrypted: false,
@@ -120,7 +111,7 @@ export const getInitialQuestionsDirect = (chainId: number) => [
     metadataExcluded: true,
   },
   {
-    id: 5,
+    id: 4,
     title: "Milestones",
     required: true,
     encrypted: false,
@@ -128,7 +119,7 @@ export const getInitialQuestionsDirect = (chainId: number) => [
     type: "paragraph",
   },
   {
-    id: 6,
+    id: 5,
     title: "Funding Sources",
     required: true,
     encrypted: false,
@@ -136,7 +127,7 @@ export const getInitialQuestionsDirect = (chainId: number) => [
     type: "short-answer",
   },
   {
-    id: 7,
+    id: 6,
     title: "Team Size",
     required: true,
     encrypted: false,

--- a/packages/round-manager/src/features/round/__tests__/ApplicationDirectPayout.test.tsx
+++ b/packages/round-manager/src/features/round/__tests__/ApplicationDirectPayout.test.tsx
@@ -279,18 +279,21 @@ describe("<ApplicationDirectPayout />", () => {
           applicationIndex: 1,
           createdAt: (moment().subtract(3, "day").valueOf() / 1000).toString(),
           txnHash: "0x00001",
+          tokenAddress: mockAddress,
         },
         {
           amount: parseUnits("2", 18).toString(),
           applicationIndex: 1,
           createdAt: (moment().subtract(2, "day").valueOf() / 1000).toString(),
           txnHash: "0x00002",
+          tokenAddress: mockAddress,
         },
         {
           amount: parseUnits("20", 18).toString(),
           applicationIndex: 2, // NOTE: This payout is for a different application
           createdAt: (moment().subtract(1, "day").valueOf() / 1000).toString(),
           txnHash: "0x00003",
+          tokenAddress: mockAddress,
         },
       ],
     });
@@ -310,7 +313,7 @@ describe("<ApplicationDirectPayout />", () => {
     expect(filas.length).toBe(2);
     expect(filas[0].textContent).toContain("0x00001");
     expect(filas[1].textContent).toContain("0x00002");
-    expect(totalPaidOut.textContent).toContain("3.0 DAI");
+    expect(totalPaidOut.textContent).toContain("Total paid out: 3.0 ETH");
   });
 
   it("should not trigger payout if not amount or vault address is entered", async () => {

--- a/packages/round-manager/src/features/round/usePayouts.tsx
+++ b/packages/round-manager/src/features/round/usePayouts.tsx
@@ -13,6 +13,7 @@ export function usePayouts(args: {
       amount: string;
       createdAt: string;
       txnHash: string;
+      tokenAddress: string;
     }[]
   >(
     args.roundId !== undefined && args.projectId !== undefined
@@ -40,6 +41,7 @@ export function usePayouts(args: {
           amount: payout.amount,
           createdAt: payout.timestamp,
           txnHash: payout.transactionHash,
+          tokenAddress: payout.tokenAddress,
         };
       });
 


### PR DESCRIPTION
Changes on Direct Grants:

This PR allows to remove the payout token from the Direct Grants Round creation form,
also it resolves the bug of setting a wrong/not existing token.

As a replacement for the pre-defined token a token list dropdown was added to the payout form.
The dropdown allows to chose a token form our payout token list and to payout with a custom token.

To Test:
- creating a direct grants round (without payout token)
- payout a grantee with a token from the dropdown
- payout a grantee with a custom token (i can send you some test token)

Screenshots:
![image](https://github.com/gitcoinco/grants-stack/assets/22886639/cd805aa7-2cde-4609-b7a4-70bb0b2985f4)
Note: RND is a Random token i used for testing which is not in the payout token list


![image](https://github.com/gitcoinco/grants-stack/assets/22886639/aa26875e-ecf4-4d31-a946-09e7bb2e5d80)
Custom token allows to paste in an address and loads the needed token information like symbol and decimals


![image](https://github.com/gitcoinco/grants-stack/assets/22886639/26b855a0-e8d6-43f3-9391-72f7d11984af)
a wrong token address shows an error