### PR TITLE
fix: ensure token address is lowercased

### DIFF
--- a/packages/round-manager/src/features/round/ViewRoundSettings.tsx
+++ b/packages/round-manager/src/features/round/ViewRoundSettings.tsx
@@ -108,8 +108,12 @@ const generateUpdateRoundData = (
     )
   ) {
     const decimals = getPayoutTokenOptions(dNewRound.chainId).find(
-      (token) => token.address === dNewRound.token
+      (token) => token.address.toLowerCase() === dNewRound.token.toLowerCase()
     )?.decimal;
+
+    if (!decimals) {
+      throw new Error("Token decimals not found");
+    }
 
     const matchAmount = ethers.utils.parseUnits(
       dNewRound?.roundMetadata?.quadraticFundingConfig?.matchingFundsAvailable.toString(),
@@ -181,10 +185,11 @@ export default function ViewRoundSettings(props: { id?: string }) {
   /* All DG rounds have rolling applications enabled */
   useEffect(() => {
     if (
-      round && round.applicationsEndTime &&
+      round &&
+      round.applicationsEndTime &&
       isInfiniteDate(round.applicationsEndTime) &&
       isDirectRound(round)
-    ) {      
+    ) {
       setRollingApplicationsEnabled(true);
     } else {
       setRollingApplicationsEnabled(false);


### PR DESCRIPTION
Currently, in production when you edit a round -> we try to find the decimals of the token and default it to 18 if it is undefined. It was being set to undefined and we were comparing checksum token address with lower token address which would always return fail  (eg:  aa == AA)
When creating a round with USDC which has 6 decimals  -> the compare would fail and it would default to 18 decimals

Fix Tested on round http://localhost:3000/#/round/0x6f008d6701daf4ab585202e95c273d4225a0bf15

This was a round created with 1 USDC as match amount and then updated to 10 USDC

![image](https://github.com/gitcoinco/grants-stack/assets/5358146/997069dd-72dc-4a75-910a-8de53edecaea)

fixes https://github.com/gitcoinco/grants-stack/issues/3421
