### PR TITLE
set public sepolia rpc

### DIFF
--- a/packages/common/src/chains.ts
+++ b/packages/common/src/chains.ts
@@ -466,14 +466,10 @@ export const sepolia: Chain = {
   ...ethereumSepolia,
   rpcUrls: {
     default: {
-      http: [
-        `https://eth-sepolia.g.alchemy.com/v2/${config.blockchain.alchemyId}`,
-      ],
+      http: [`https://rpc2.sepolia.org`],
     },
     public: {
-      http: [
-        `https://eth-sepolia.g.alchemy.com/v2/${config.blockchain.alchemyId}`,
-      ],
+      http: [`https://rpc2.sepolia.org`],
     },
   },
 };


### PR DESCRIPTION
Set the public rpc for sepolia so that we don't require infura/alchemy accounts for local development