### PR TITLE
removing round operator filter

### DIFF
--- a/packages/common/src/allo/backends/allo-v2.ts
+++ b/packages/common/src/allo/backends/allo-v2.ts
@@ -470,8 +470,6 @@ export class AlloV2 implements Allo {
         this.chainId
       );
 
-      console.log("args", args);
-
       if (args.roundData.roundCategory === RoundCategory.QuadraticFunding) {
         const initStrategyData: DonationVotingMerkleDistributionStrategyTypes.InitializeData =
           {
@@ -540,15 +538,11 @@ export class AlloV2 implements Allo {
           chain: this.chainId,
         });
 
-        console.log("===> 1");
-
         initStrategyDataEncoded =
           await strategy.getInitializeData(initStrategyData);
 
         const alloToken =
           args.roundData.token === zeroAddress ? NATIVE : args.roundData.token;
-
-        console.log("===> 2", alloToken);
 
         token = getAddress(alloToken);
       } else if (args.roundData.roundCategory === RoundCategory.Direct) {
@@ -636,8 +630,6 @@ export class AlloV2 implements Allo {
           getAddress(operator)
         ),
       };
-
-      console.log("createPoolArgs", createPoolArgs);
 
       let txData: TransactionData;
 

--- a/packages/round-manager/src/features/api/round.ts
+++ b/packages/round-manager/src/features/api/round.ts
@@ -152,21 +152,12 @@ export async function listRounds(args: {
 }): Promise<{ rounds: Round[] }> {
   const { chainId, dataLayer, programId } = args;
 
-  let rounds = await dataLayer
+  const rounds = await dataLayer
     .getRoundsForManager({
       chainId: chainId,
       programId,
     })
     .then((rounds) => rounds.map(indexerV2RoundToRound));
-
-  // Filter out rounds where operatorWallets does not include round.createdByAddress
-  // This is to filter out spam rounds created by bots
-  rounds = rounds.filter((round) => {
-    return (
-      round.createdByAddress &&
-      round.operatorWallets?.includes(round.createdByAddress)
-    );
-  });
 
   return { rounds };
 }


### PR DESCRIPTION
Removing the Round operator filter.
If we encounter the spam rounds again, we need to think about a different way to handle them (maybe black listing)

See: https://discord.com/channels/562828676480237578/1234146304108531852

