### PR TITLE
fix(explorer): description missing on project card with footer

### DIFF
--- a/packages/grant-explorer/src/features/round/ViewRoundPage.tsx
+++ b/packages/grant-explorer/src/features/round/ViewRoundPage.tsx
@@ -14,7 +14,6 @@ import {
   getLocalTime,
   formatLocalDateAsISOString,
   renderToPlainText,
-  truncateDescription,
   useTokenPrice,
   TToken,
   getTokensByChainId,
@@ -757,7 +756,10 @@ function ProjectCard(props: {
   cartProject.chainId = Number(props.chainId);
 
   return (
-    <BasicCard className="relative w-full" data-testid="project-card">
+    <BasicCard
+      className={`relative w-full ${props.showProjectCardFooter ? "h-[370px]" : "h-[310px]"}`}
+      data-testid="project-card"
+    >
       <Link
         to={`${roundRoutePath}/${project.grantApplicationId}`}
         data-testid="project-detail-link"
@@ -793,12 +795,9 @@ function ProjectCard(props: {
           </div>
           <CardDescription
             data-testid="project-description"
-            className={`h-[${props.showProjectCardFooter ? "130px" : "100px"}] overflow-hidden mb-1 !text-sm`}
+            className={`mb-1 !text-sm`}
           >
-            {truncateDescription(
-              renderToPlainText(project.projectMetadata.description),
-              90
-            )}
+            {renderToPlainText(project.projectMetadata.description)}
           </CardDescription>
         </CardContent>
       </Link>


### PR DESCRIPTION
<!-- Thank you for your pull request! Before marking it as "Ready for review",
please ensure that all items of checklist are satisfied and that CI checks are
passing.  -->

Fixes: #issue

## Description

In ViewRoundPage:

ProjectCards were not displaying the description if the ProjectCard footer was being displayed. 

## Checklist

This PR:

- [ ] Does it add new payout or donation token? In this case, have they been added to the indexer to avoid it to crash?
- [ ] Includes only changes relevant to the original ticket. Significant refactoring needs to be separated.
- [ ] Doesn't disable eslint rules.
- [ ] Doesn't work around the type checker (including but not limited to: type casts, non-null assertions, `@ts-ignore`, unjustified optional values).
- [ ] Doesn't contain commented out code.
- [ ] If adding/updating a feature, it adds/updates its test script on Notion.
