### PR TITLE
feat(explorer): show project list in preround page

### DIFF
--- a/packages/grant-explorer/src/features/api/utils.ts
+++ b/packages/grant-explorer/src/features/api/utils.ts
@@ -77,24 +77,52 @@ export const pinToIPFS = (obj: IPFSObject) => {
   }
 };
 
-export const getDaysLeft = (fromNowToTimestampStr: string) => {
+export interface TimeLeft {
+  days?: number;
+  hours?: number;
+  minutes?: number;
+  seconds?: number;
+}
+
+export const getTimeLeft = (fromNowToTimestampStr: string): TimeLeft => {
   const targetTimestamp = Number(fromNowToTimestampStr);
 
   // Some timestamps are returned as overflowed (1.15e+77)
   // We parse these into undefined to show as "No end date" rather than make the date diff calculation
   if (targetTimestamp > Number.MAX_SAFE_INTEGER) {
-    return undefined;
+    return {};
   }
 
   // TODO replace with differenceInCalendarDays from 'date-fns'
   const currentTimestampInSeconds = Math.floor(Date.now() / 1000); // current timestamp in seconds
   const secondsPerDay = 60 * 60 * 24; // number of seconds per day
+  const secondsPerHour = 60 * 60; // number of seconds per day
+  const secondsPerMinute = 60;
 
   const differenceInSeconds = targetTimestamp - currentTimestampInSeconds;
-  const differenceInDays = Math.floor(differenceInSeconds / secondsPerDay);
 
-  return differenceInDays;
+  const days = Math.floor(differenceInSeconds / secondsPerDay);
+  const hours = Math.floor(differenceInSeconds / secondsPerHour) % 24; // % 24 to substract total days
+  const minutes = Math.floor(differenceInSeconds / secondsPerMinute) % 60; // % 60 to substract total hours
+  const seconds = Math.floor(differenceInSeconds) % 60; // % 60 to substract total minutes
+
+  return { days, hours, minutes, seconds };
 };
+
+export const parseTimeLeftString = (timeLeft: TimeLeft): string => {
+  const { days = 0, hours = 0, minutes = 0 } = timeLeft;
+
+  const daysString = days > 0 ? `${days} ${days === 1 ? "day" : "days"}, ` : "";
+  const hoursString =
+    hours > 0 ? `${hours} ${hours === 1 ? "hour" : "hours"}, ` : "";
+  const minutesString =
+    minutes > 0 ? `${minutes} ${minutes === 1 ? "minute" : "minutes"}` : "";
+
+  return `${daysString}${hoursString}${minutesString}`;
+};
+
+export const getDaysLeft = (fromNowToTimestampStr: string) =>
+  getTimeLeft(fromNowToTimestampStr).days;
 
 export const isDirectRound = (round: Round) =>
   // @ts-expect-error support old rounds

--- a/packages/grant-explorer/src/features/common/styles.tsx
+++ b/packages/grant-explorer/src/features/common/styles.tsx
@@ -71,6 +71,7 @@ const colorMap = {
   grey: "bg-grey-100",
   yellow: "bg-yellow-100",
   orange: "bg-orange-100",
+  rainbow: "bg-rainbow-gradient",
 } as const;
 
 const roundedMap = {

--- a/packages/grant-explorer/src/features/round/ApplicationsCountdownBanner.tsx
+++ b/packages/grant-explorer/src/features/round/ApplicationsCountdownBanner.tsx
@@ -1,0 +1,95 @@
+import { Button } from "common/src/styles";
+import { TimeLeft, getTimeLeft, parseTimeLeftString } from "../api/utils";
+
+type ApplicationPeriodStatus =
+  | "pre-application"
+  | "post-application"
+  | "during-application";
+
+const generateCountdownString = (
+  targetDate: Date | undefined
+): string | undefined => {
+  if (!targetDate) return undefined;
+
+  const targetDateString = Math.round(targetDate.getTime() / 1000).toString();
+  const timeLeft: TimeLeft = getTimeLeft(targetDateString);
+
+  const timeLeftString: string = parseTimeLeftString(timeLeft);
+
+  return timeLeftString;
+};
+
+const generateBannerString = (
+  status: ApplicationPeriodStatus,
+  targetDate: Date | undefined
+): string => {
+  switch (status) {
+    case "pre-application":
+      return `Applications open in ${generateCountdownString(targetDate)}!`;
+    case "during-application":
+      return `Applications close in ${generateCountdownString(targetDate)}!`;
+    case "post-application":
+      return `Applications are closed`;
+    default:
+      throw new Error("Unknown ApplicationPeriodStatus");
+  }
+};
+
+function ApplicationsCountdownBanner(props: {
+  startDate: Date;
+  endDate: Date;
+  applicationURL: string;
+}) {
+  const { startDate, endDate, applicationURL } = props;
+
+  let targetDate: Date | undefined = undefined;
+  let status: ApplicationPeriodStatus = "post-application";
+
+  const currentTime = new Date();
+
+  const isBeforeApplicationPeriod = currentTime < startDate;
+  const isDuringApplicationPeriod =
+    currentTime >= startDate && currentTime < endDate;
+
+  if (isDuringApplicationPeriod) {
+    targetDate = endDate;
+    status = "during-application";
+  } else if (isBeforeApplicationPeriod) {
+    targetDate = startDate;
+    status = "pre-application";
+  }
+
+  const bannerString = generateBannerString(status, targetDate);
+
+  return (
+    <div className="flex flex-col items-center bg-grey-50 w-fit py-6 px-36 rounded-2xl">
+      <p>{bannerString}</p>
+      <ApplyButton status={status} applicationURL={applicationURL} />
+    </div>
+  );
+}
+
+const ApplyButton = (props: {
+  status: ApplicationPeriodStatus;
+  applicationURL: string;
+  testid?: string;
+}) => {
+  const { status, applicationURL } = props;
+
+  return (
+    <Button
+      type="button"
+      onClick={() => window.open(applicationURL, "_blank")}
+      className="bg-orange-100 text-grey-500 mt-2 basis-full items-center justify-center shadow-sm text-sm rounded md:h-12"
+      data-testid={
+        status === "during-application"
+          ? "apply-button"
+          : "view-requirements-button"
+      }
+    >
+      {status === "during-application" ? "Apply now!" : "Check requirements"}
+    </Button>
+  );
+};
+
+export default ApplicationsCountdownBanner;

--- a/packages/grant-explorer/src/features/round/RoundStartCountdownBadge.tsx
+++ b/packages/grant-explorer/src/features/round/RoundStartCountdownBadge.tsx
@@ -1,0 +1,26 @@
+import { TimeLeft, getTimeLeft, parseTimeLeftString } from "../api/utils";
+import { Badge } from "../common/styles";
+
+function RoundStartCountdownBadge(props: { targetDate: Date }) {
+  const { targetDate } = props;
+
+  const targetDateString = Math.round(targetDate.getTime() / 1000).toString();
+
+  const timeLeft: TimeLeft = getTimeLeft(targetDateString);
+  const timeLeftString: string = parseTimeLeftString(timeLeft);
+
+  const badgeString = `Donations start in ${timeLeftString}`;
+
+  return (
+    <Badge
+      color="rainbow"
+      rounded="full"
+      className="flex-shrink-0 px-2.5 font-modern-era-bold"
+      data-testid="donations-countdown-badge"
+    >
+      {badgeString}
+    </Badge>
+  );
+}
+
+export default RoundStartCountdownBadge;

--- a/packages/grant-explorer/src/features/round/ViewProjectDetails.tsx
+++ b/packages/grant-explorer/src/features/round/ViewProjectDetails.tsx
@@ -139,6 +139,12 @@ export default function ViewProjectDetails() {
       ? false
       : round && round.roundEndTime <= currentTime);
 
+  const isBeforeRoundStartDate =
+    round &&
+    (isInfiniteDate(round.roundStartTime)
+      ? false
+      : round && currentTime < round.roundStartTime);
+
   const alloVersion = getAlloVersion();
 
   useEffect(() => {
@@ -154,7 +160,8 @@ export default function ViewProjectDetails() {
 
   const disableAddToCartButton =
     (alloVersion === "allo-v2" && roundId.startsWith("0x")) ||
-    isAfterRoundEndDate;
+    isAfterRoundEndDate ||
+    isBeforeRoundStartDate;
   const { projects, add, remove } = useCartStorage();
 
   const isAlreadyInCart = projects.some(

--- a/packages/grant-explorer/src/features/round/__tests__/ViewRoundPage.test.tsx
+++ b/packages/grant-explorer/src/features/round/__tests__/ViewRoundPage.test.tsx
@@ -103,15 +103,14 @@ describe("<ViewRound /> in case of before the application start date", () => {
     });
   });
 
-  it("Should show grayed out Applications Open buttom", async () => {
+  it("Should show View Requirements Button", async () => {
     renderWithContext(<ViewRound />, {
       roundState: { rounds: [stubRound], isLoading: false },
       dataLayer: mockDataLayer,
     });
 
-    const AppSubmissionButton = screen.getByTestId("applications-open-button");
+    const AppSubmissionButton = screen.getByTestId("view-requirements-button");
     expect(AppSubmissionButton).toBeInTheDocument();
-    expect(AppSubmissionButton).toBeDisabled();
   });
 });
 
@@ -154,14 +153,13 @@ describe("<ViewRound /> in case of during the application period", () => {
     });
 
     // expect that components / text / dates / etc. specific to  application view page
-    expect(screen.getByText(stubRound.roundMetadata!.name)).toBeInTheDocument();
+    expect(screen.getAllByText(stubRound.roundMetadata!.name)).toHaveLength(2);
     expect(screen.getByTestId("application-period")).toBeInTheDocument();
     expect(screen.getByTestId("round-period")).toBeInTheDocument();
     expect(screen.getByTestId("matching-funds")).toBeInTheDocument();
     expect(
       screen.getByText(stubRound.roundMetadata!.eligibility!.description)
     ).toBeInTheDocument();
-    expect(screen.getByTestId("round-eligibility")).toBeInTheDocument();
   });
 
   it("Should show apply to round button", async () => {
@@ -169,9 +167,7 @@ describe("<ViewRound /> in case of during the application period", () => {
       roundState: { rounds: [stubRound], isLoading: false },
       dataLayer: mockDataLayer,
     });
-    const AppSubmissionButton = await screen.findAllByText(
-      "Apply to Grant Round"
-    );
+    const AppSubmissionButton = await screen.findAllByText("Apply now!");
     expect(AppSubmissionButton[0]).toBeInTheDocument();
   });
 });
@@ -198,17 +194,15 @@ describe("<ViewRound /> in case of post application end date & before round star
     });
   });
 
-  it("Should show Applications Closed button", async () => {
+  it("Should show Donations countdown badge", async () => {
     renderWithContext(<ViewRound />, {
       roundState: { rounds: [stubRound], isLoading: false },
       dataLayer: mockDataLayer,
     });
-
-    const AppSubmissionButton = screen.getByTestId(
-      "applications-closed-button"
+    const DonationsBadge = await screen.getByTestId(
+      "donations-countdown-badge"
     );
-    expect(AppSubmissionButton).toBeInTheDocument();
-    expect(AppSubmissionButton).toBeDisabled();
+    expect(DonationsBadge).toBeInTheDocument();
   });
 });
 

--- a/packages/grant-explorer/tailwind.config.js
+++ b/packages/grant-explorer/tailwind.config.js
@@ -12,6 +12,10 @@ module.exports = {
       animation: {
         "pulse-scale": "pulse-scale 2s ease-in-out infinite",
       },
+      backgroundImage: {
+        "rainbow-gradient":
+          "linear-gradient(170deg, #FFD6C9 10%, #B8D9E7 40%, #ABE3EB 60%, #F2DD9E 90%)",
+      },
       colors: {
         transparent: "transparent",
         black: "#000",
@@ -37,7 +41,7 @@ module.exports = {
         },
         green: {
           ...colors.green,
-           50: "#DCF5F2",
+          50: "#DCF5F2",
           100: "#ADEDE5",
           200: "#47A095",
           300: "rgba(0, 67, 59, 1)",


### PR DESCRIPTION
<!-- Thank you for your pull request! Before marking it as "Ready for review",
please ensure that all items of checklist are satisfied and that CI checks are
passing.  -->

Fixes: #issue

## Description

We remove the old pre-round page, and reuse the after round start page:

- src/features/api/utils.ts:
  -  implemented getTimeLeft function reusing the logic of getDaysLeft, to return an object { days, hours, minutes, seconds } with the time left values based on a timestamp passed as argument
  - getDaysLeft now uses getTimeLeft
  - implemented parseTimeLeftString that receives as argument the same structure that getTimeLeft returns, and converts is to string with the format `X days, X hours, X minures`
- src/features/common/styles.tsx & tailwind.config.js:
  - extended TW theme with a rainbow gradiend background to use it in a badge 
- src/features/round/ViewProjectDetails.tsx:
  - cart button now is hidden in pre-round period
- src/features/round/ApplicationsCountdownBanner.tsx & RoundStartCountdownBadge.tsx:
  - implemented countdown banner and badge for pre-round period page
- src/features/round/ViewRoundPage.tsx:
  - removed BeforeRoundStart component
  - refactored AfterRoundStart (now named RoundPage) to have a unified page for both before and after round has started, the changes are adding a badge and banner with countdowns for applications and round start period, and removing the carts in preround period.

