### PR TITLE
keep the finalize round button always enabled

### DIFF
--- a/packages/round-manager/src/features/round/ViewRoundResults/ViewRoundResults.tsx
+++ b/packages/round-manager/src/features/round/ViewRoundResults/ViewRoundResults.tsx
@@ -1269,7 +1269,6 @@ function FinalizeResultsButton(props: {
         onClick={() => {
           props.setWarningModalOpen(true);
         }}
-        disabled={!props.isRoundFullyFunded}
         className={`self-end w-fit ${
           props.isRoundFullyFunded ? "bg-violet-400" : "bg-violet-200"
         } text-white py-2 mt-2 px-3 rounded`}

--- a/packages/round-manager/src/features/round/ViewRoundResults/ViewRoundResults.tsx
+++ b/packages/round-manager/src/features/round/ViewRoundResults/ViewRoundResults.tsx
@@ -1269,9 +1269,7 @@ function FinalizeResultsButton(props: {
         onClick={() => {
           props.setWarningModalOpen(true);
         }}
-        className={`self-end w-fit ${
-          props.isRoundFullyFunded ? "bg-violet-400" : "bg-violet-200"
-        } text-white py-2 mt-2 px-3 rounded`}
+        className={`self-end w-fit ${"bg-violet-400"} text-white py-2 mt-2 px-3 rounded`}
       >
         Finalize Results
       </button>


### PR DESCRIPTION
Keep the finalize round button always enabled instead of checking if the pool is completely funded. 
This is needed in case the round operator wants to distribute less funds only to some grantees.