### PR TITLE
[FIX] Bug 3291 - Can now select full area for project logo

### DIFF
--- a/packages/builder/src/components/base/images/ImageCrop.tsx
+++ b/packages/builder/src/components/base/images/ImageCrop.tsx
@@ -91,8 +91,6 @@ export default function ImageCrop({
               setCompletedCrop(c);
             }}
             aspect={dimensions.width / dimensions.height}
-            maxHeight={undefined}
-            maxWidth={undefined}
           >
             <img
               ref={imgRef}

--- a/packages/builder/src/components/base/images/ImageCrop.tsx
+++ b/packages/builder/src/components/base/images/ImageCrop.tsx
@@ -91,8 +91,8 @@ export default function ImageCrop({
               setCompletedCrop(c);
             }}
             aspect={dimensions.width / dimensions.height}
-            maxHeight={dimensions.height}
-            maxWidth={dimensions.width}
+            maxHeight={undefined}
+            maxWidth={undefined}
           >
             <img
               ref={imgRef}


### PR DESCRIPTION
Fixes: #3291 

## Description

Fixes the bug where only a portion of an image can be selected for a project's logo. See image below.

![Screenshot 2024-08-06 at 21 47 42](https://github.com/user-attachments/assets/eb1b81a9-a167-4625-8ee9-49636f2328b7)

## Checklist

This PR:

- [ ] Does it add new payout or donation token? In this case, have they been added to the indexer to avoid it to crash?
- [X] Includes only changes relevant to the original ticket. Significant refactoring needs to be separated.
- [X] Doesn't disable eslint rules.
- [X] Doesn't work around the type checker (including but not limited to: type casts, non-null assertions, `@ts-ignore`, unjustified optional values).
- [X] Doesn't contain commented out code.
- [ ] If adding/updating a feature, it adds/updates its test script on Notion.
