### PR TITLE
fix(PAR-208): search projects by multiple words

### DIFF
--- a/packages/grant-explorer/src/features/discovery/ExploreProjectsPage.tsx
+++ b/packages/grant-explorer/src/features/discovery/ExploreProjectsPage.tsx
@@ -46,7 +46,7 @@ export function ExploreProjectsPage(): JSX.Element {
 
   function onSearchSubmit(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault();
-    setSearchQuery(searchInput);
+    setSearchQuery(`'${searchInput}'`);
   }
 
   return (


### PR DESCRIPTION
in the indexer in the file migrate.ts, the search_projects function is using to_tsquery that does not accept espaces, a solution is to wrap the phrase in single quotes.
