### PR TITLE
fix: ensure all columns are present in csv

### DIFF
--- a/packages/round-manager/src/features/api/exports.ts
+++ b/packages/round-manager/src/features/api/exports.ts
@@ -55,11 +55,16 @@ export async function roundApplicationsToCSV(
   });
 
   const decryptedData: Record<string, string>[] = [];
+  const columns = new Set();
+
 
   for (const application of applications) {
     const answers =
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       application.metadata?.application.answers.flatMap((answer: any) => {
+
+        columns.add(answer.question);
+
         if (answer.answer) {
           return [[answer.question, answer.answer]];
         } else if (answer.encryptedAnswer) {
@@ -109,8 +114,10 @@ export async function roundApplicationsToCSV(
     });
   }
 
+  const columnsArray = Array.from(columns) as string[];
+
   const csv = (await new Promise((resolve, reject) => {
-    stringifyCsv(decryptedData, { header: true }, (err, data) => {
+    stringifyCsv(decryptedData, { header: true , columns: columnsArray}, (err, data) => {
       if (err) {
         reject(err);
       } else {
@@ -118,6 +125,5 @@ export async function roundApplicationsToCSV(
       }
     });
   })) as string;
-
   return csv;
 }


### PR DESCRIPTION
The plugin we use to stringy decides what the columns are by the first entry. If user skips a question -> we don't have that column and the data is not exported.
This PR just generates a set of all questions AKA columns and set that to ensure all questions/answers are accounted for 
![Uploading Deploy.gif…]()

