### PR TITLE
fix: apply consistent 2 decimal places in UI.

### DIFF
--- a/packages/grant-explorer/src/features/round/ViewRoundPage.tsx
+++ b/packages/grant-explorer/src/features/round/ViewRoundPage.tsx
@@ -815,6 +815,7 @@ function ProjectCard(props: {
                 <p>
                   $
                   {props.crowdfundedUSD?.toLocaleString("en-US", {
+                    minimumFractionDigits: 2,
                     maximumFractionDigits: 2,
                   })}
                 </p>


### PR DESCRIPTION
<!-- Thank you for your pull request! Before marking it as "Ready for review",
please ensure that all items of checklist are satisfied and that CI checks are
passing.  -->

Fixes: #3607 

## Description

This PR addresses the Cosmetic UI issue to ensure all figures displayed contain 2 decimal places for consistency on the frontend. 

## Checklist

This PR:

- [x] Includes only changes relevant to the original ticket. Significant refactoring needs to be separated.
- [x] Doesn't disable eslint rules.
- [x] Doesn't work around the type checker (including but not limited to: type casts, non-null assertions, `@ts-ignore`, unjustified optional values).
- [x] Doesn't contain commented out code.
- [ ] If adding/updating a feature, it adds/updates its test script on Notion.
- [ ] Does it add new payout or donation token? In this case, have they been added to the indexer to avoid it to crash?
