### PR TITLE
fix:reduntant message if only one network

### DIFF
--- a/packages/grant-explorer/src/features/round/ViewCartPage/ChainConfirmationModalBody.tsx
+++ b/packages/grant-explorer/src/features/round/ViewCartPage/ChainConfirmationModalBody.tsx
@@ -43,8 +43,12 @@ export function ChainConfirmationModalBody({
   return (
     <>
       <p className="text-sm text-grey-400">
-        Checkout all your carts across different networks or select the cart you
-        wish to checkout now.
+      {chainIdsBeingCheckedOut.length > 1 && (
+          <>
+            Checkout all your carts across different networks or select the cart
+            you wish to checkout now.
+          </>
+        )}
       </p>
       <div className="my-4">
         {Object.keys(projectsByChain)


### PR DESCRIPTION
<!-- Thank you for your pull request! Before marking it as "Ready for review",
please ensure that all items of checklist are satisfied and that CI checks are
passing.  -->

Fixes: #3604 

## Description

<!-- Describe your changes here. -->
Render checkout message to different network only when more than one contribution is made for different networks.

## Checklist

This PR:

- [ ] Does it add new payout or donation token? In this case, have they been added to the indexer to avoid it to crash?
- [ ] Includes only changes relevant to the original ticket. Significant refactoring needs to be separated.
- [ ] Doesn't disable eslint rules.
- [ ] Doesn't work around the type checker (including but not limited to: type casts, non-null assertions, `@ts-ignore`, unjustified optional values).
- [ ] Doesn't contain commented out code.
- [ ] If adding/updating a feature, it adds/updates its test script on Notion.
