### PR TITLE
chore: remove unused esmModules config

### DIFF
--- a/packages/builder/craco.config.js
+++ b/packages/builder/craco.config.js
@@ -7,14 +7,6 @@ config({
   path: path.join(__dirname, "../../.env"),
 });
 
-const esmModules = [
-  "@rainbow-me",
-  "@spruceid",
-  "wagmi",
-  "@wagmi",
-  "github\\.com\\+gitcoinco\\+allo\\-indexer\\-client",
-];
-
 module.exports = {
   webpack: {
     plugins: {


### PR DESCRIPTION
Removes an unused esmModules constant that is no longer referenced anywhere in the config.